### PR TITLE
fix merging with python (uint8_t vs size_t screwed the length/pystr give...

### DIFF
--- a/mtbl.pyx
+++ b/mtbl.pyx
@@ -441,8 +441,8 @@ cdef class writer(object):
 
 cdef void merge_func_wrapper(void *clos,
         uint8_t *key, size_t len_key,
-        uint8_t *val0, uint8_t len_val0,
-        uint8_t *val1, uint8_t len_val1,
+        uint8_t *val0, size_t len_val0,
+        uint8_t *val1, size_t len_val1,
         uint8_t **merged_val, size_t *len_merged_val) with gil:
     cdef str py_key
     cdef str py_val0


### PR DESCRIPTION
Anything value merged with python that is longer than 255 was broken in the resulting mtbl as the signature of merge_func_wrapper was incorrect.

Discovered as some of our datasets got screwed up after merging.