### PR TITLE
Add LZ4/LZ4HC compression types

### DIFF
--- a/mtbl.pxi
+++ b/mtbl.pxi
@@ -15,6 +15,8 @@ cdef extern from "mtbl.h":
         MTBL_COMPRESSION_NONE
         MTBL_COMPRESSION_SNAPPY
         MTBL_COMPRESSION_ZLIB
+        MTBL_COMPRESSION_LZ4
+        MTBL_COMPRESSION_LZ4HC
 
     struct mtbl_iter:
         pass

--- a/mtbl.pyx
+++ b/mtbl.pyx
@@ -7,6 +7,8 @@ DEFAULT_SORTER_MEMORY = 1073741824
 COMPRESSION_NONE = MTBL_COMPRESSION_NONE
 COMPRESSION_SNAPPY = MTBL_COMPRESSION_SNAPPY
 COMPRESSION_ZLIB = MTBL_COMPRESSION_ZLIB
+COMPRESSION_LZ4 = MTBL_COMPRESSION_LZ4
+COMPRESSION_LZ4HC = MTBL_COMPRESSION_LZ4HC
 
 class KeyOrderError(Exception):
     pass
@@ -384,7 +386,9 @@ cdef class writer(object):
             size_t block_restart_interval=16):
         if not (compression == COMPRESSION_NONE or
                 compression == COMPRESSION_SNAPPY or
-                compression == COMPRESSION_ZLIB):
+                compression == COMPRESSION_ZLIB or
+                compression == COMPRESSION_LZ4 or
+                compression == COMPRESSION_LZ4HC):
             raise UnknownCompressionTypeException
 
         self._lock = threading.Semaphore()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ try:
     setup(
         name = NAME,
         version = VERSION,
-        ext_modules = [ Extension('mtbl', ['mtbl.pyx'], **pkgconfig('libmtbl')) ],
+        ext_modules = [ Extension('mtbl', ['mtbl.pyx'], **pkgconfig('libmtbl >= 0.8.0')) ],
         cmdclass = {'build_ext': build_ext},
     )
 except ImportError:
@@ -35,7 +35,7 @@ except ImportError:
         setup(
             name = NAME,
             version = VERSION,
-            ext_modules = [ Extension('mtbl', ['mtbl.c'], **pkgconfig('libmtbl')) ],
+            ext_modules = [ Extension('mtbl', ['mtbl.c'], **pkgconfig('libmtbl >= 0.8.0')) ],
         )
     else:
         raise


### PR DESCRIPTION
This commit adds support for the LZ4 and LZ4HC compression types that
will be introduced in mtbl 0.8.0.