### PR TITLE
Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+venv*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,121 @@ mtbl.c
 examples/*.mtbl
 examples/wf/*.mtbl
 examples/wf/*.txt
+
+
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2014 by Farsight Security, Inc.
+Copyright (c) 2012-2019 by Farsight Security, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -9,45 +9,92 @@ writer interfaces (nb. the traceback is expected behavior):
 
     >>> import mtbl
     >>> w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
-    >>> w[b'key1'] = b'val1'
-    >>> w[b'key17'] = b'val17'
-    >>> w[b'key2'] = b'val2'
-    >>> w[b'key23'] = b'val23'
-    >>> w[b'key3'] = b'val3'
-    >>> w[b'key4'] = b'val4'
-    >>> w[b'key05'] = b'val05'
+    >>> w['key1'] = 'val1'
+    >>> w['key17'] = 'val17'
+    >>> w['key2'] = 'val2'
+    >>> w['key23'] = 'val23'
+    >>> w['key3'] = 'val3'
+    >>> w['key4'] = 'val4'
+    >>> w['key05'] = 'val05'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File "mtbl.pyx", line 361, in mtbl.writer.__setitem__ (mtbl.c:4108)
     mtbl.KeyOrderError
     >>> w.close()
     >>> r = mtbl.reader('example.mtbl', verify_checksums=True)
-    >>> for k,v in r.get_range(b'key19', b'key23'): print(k, v)
+    >>> for k,v in r.get_range('key19', 'key23'): print(k, v)
     ... 
-    b'key2' b'val2'
-    b'key23' b'val23'
-    >>> for k,v in r.get_prefix(b'key2'): print(k, v)
+    'key2' 'val2'
+    'key23' 'val23'
+    >>> for k,v in r.get_prefix('key2'): print(k, v)
     ... 
-    b'key2' b'val2'
-    b'key23' b'val23'
+    'key2' 'val2'
+    'key23' 'val23'
     >>> for k,v in r.iteritems(): print(k, v)
     ... 
-    b'key1' b'val1'
-    b'key17' b'val17'
-    b'key2' b'val2'
-    b'key23' b'val23'
-    b'key3' b'val3'
-    b'key4' b'val4'
+    'key1' 'val1'
+    'key17' 'val17'
+    'key2' 'val2'
+    'key23' 'val23'
+    'key3' 'val3'
+    'key4' 'val4'
     >>>
 
 
 In Python 3.x bytes() is a distinct type, whereas in Python 2.6 and 2.7 
-it is simply an alias for str(). We now take bytes as function parameters
-instead of strings. This is done because, in Python 3, not all byte strings
-can be encoded as printable strings and so accepting a str as a parameter was
-not practical since mtbl is used, frequently, to store arbitrary byte data.
+it is simply an alias for str(). We now take strings and bytes as function parameters. Note that if you pass in a byte 
+string that can be UTF-8 decoded it will be read back from the mtbl as a str.
 
-Scripts that used ord() to determine the value of a byte in a buffer returned
+For example:
+
+```
+import mtbl
+w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
+w[b'key0'] = b'val0'
+w[b'key1'] = b'\x01'
+w[b'key2'] = b'\x7e'
+w[b'key3'] = b'\x80\x01'
+w.close()
+
+r = mtbl.reader('example.mtbl', verify_checksums=True)
+
+assert r.get(b'key0') == ['val0']
+# all the keys in this mtbl are strings because they can all be UTF-8 decoded
+assert [type(k) for k in list(r.iterkeys())] == [str, str, str, str]
+assert r.get('key1') == ['\x01']
+assert r.get('key2') == ['~']
+assert r.get('key3') == [b'\x80\x01'] # not a printable string so the value read back is bytes
+```
+
+If you want to disable this behavior and read the contents of the mtbl as bytes then initialize your reader with `return_bytes=True`
+
+```
+r = mtbl.reader('example.mtbl', verify_checksums=True, return_bytes=True)
+```
+
+If you want to store integers in your mtbl use varint_encode() and varint_decode() or [struct.pack](https://docs.python.org/3.9/library/struct.html#struct.pack) and [struct.unpack](https://docs.python.org/3.9/library/struct.html#struct.pack) to do so:
+
+```
+import mtbl
+import struct
+
+w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
+w['key0'] = mtbl.varint_encode(2)
+w['key1'] = mtbl.varint_encode(128)
+w['key2'] = mtbl.varint_encode(98765432100)
+w['key3'] = struct.pack('I', 123)
+w.close()
+
+r = mtbl.reader('example.mtbl', verify_checksums=True, return_bytes=True)
+
+assert mtbl.varint_decode(r.get('key0')[0]) == 2
+assert mtbl.varint_decode(r.get('key1')[0]) == 128
+assert mtbl.varint_decode(r.get('key2')[0]) == 98765432100
+assert struct.unpack('I', r.get('key3')[0])[0] == 123
+```
+
+
+Finally, scripts that used ord() to determine the value of a byte in a buffer returned
 by this module under Python 2 will now need to test the data type. 
 
 For example, in pymtbl<=0.4.0 you might have written:
@@ -61,31 +108,8 @@ Now you would write:
 
 ```
 x = mtbl.varint_encode(1234)
-if type(first_type) == str:  # py2
+if type(x) == str: # py2
     first_byte = ord(x[0])
-else:                        # py3
+else: # py3
     first_byte = x[0]
 ```
-
-Additionally, you must now pass in bytes to functions like
-varint_encode and writer. Previously, you were able to write either
-`w['key1'] = 'val1'` or `w[b'key1'] = b'val1'` because of Python 2's 
-definition of bytes == str. Now you must write either
-
- `w[b'key1'] = b'val1'` 
- 
- `w['key1'.encode()] = 'val1'.encode()`
-
-While `w['key1'] = 'val1'` will continue to work when using Python 2, it will
-*not* work when using Python 3 and so to maximize portability of your scripts, you 
-should avoid that form.
-
-If you intend to store strings, you should call encode() to ensure they
-are stored with an encoding that you define.
-
-References
-----------
-
-https://candide-guevara.github.io/article/python/2018/02/28/cython-memory-mgt.html
-https://github.com/cython/cython/blob/master/tests/run/bytearray_coercion.pyx
-

--- a/README.md
+++ b/README.md
@@ -5,37 +5,87 @@ pymtbl: Python bindings for the mtbl sorted string table library
 [mtbl](https://github.com/farsightsec/mtbl)'s reader, writer, sorter, and
 merger interfaces. The `examples/` directory contains scripts demonstrating
 each of these interfaces. The following transcript shows the basic reader and
-writer interfaces:
+writer interfaces (nb. the traceback is expected behavior):
 
     >>> import mtbl
     >>> w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
-    >>> w['key1'] = 'val1'
-    >>> w['key17'] = 'val17'
-    >>> w['key2'] = 'val2'
-    >>> w['key23'] = 'val23'
-    >>> w['key3'] = 'val3'
-    >>> w['key4'] = 'val4'
-    >>> w['key05'] = 'val05'
+    >>> w[b'key1'] = b'val1'
+    >>> w[b'key17'] = b'val17'
+    >>> w[b'key2'] = b'val2'
+    >>> w[b'key23'] = b'val23'
+    >>> w[b'key3'] = b'val3'
+    >>> w[b'key4'] = b'val4'
+    >>> w[b'key05'] = b'val05'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File "mtbl.pyx", line 361, in mtbl.writer.__setitem__ (mtbl.c:4108)
     mtbl.KeyOrderError
     >>> w.close()
     >>> r = mtbl.reader('example.mtbl', verify_checksums=True)
-    >>> for k,v in r.get_range('key19', 'key23'): print k,v
+    >>> for k,v in r.get_range(b'key19', b'key23'): print(k, v)
     ... 
-    key2 val2
-    key23 val23
-    >>> for k,v in r.get_prefix('key2'): print k,v
+    b'key2' b'val2'
+    b'key23' b'val23'
+    >>> for k,v in r.get_prefix(b'key2'): print(k, v)
     ... 
-    key2 val2
-    key23 val23
-    >>> for k,v in r.iteritems(): print k, v
+    b'key2' b'val2'
+    b'key23' b'val23'
+    >>> for k,v in r.iteritems(): print(k, v)
     ... 
-    key1 val1
-    key17 val17
-    key2 val2
-    key23 val23
-    key3 val3
-    key4 val4
+    b'key1' b'val1'
+    b'key17' b'val17'
+    b'key2' b'val2'
+    b'key23' b'val23'
+    b'key3' b'val3'
+    b'key4' b'val4'
     >>>
+
+
+In Python 3.x bytes() is a distinct type, whereas in Python 2.6 and 2.7 
+it is simply an alias for str(). We now take bytes as function parameters
+instead of strings. This is done because, in Python 3, not all byte strings
+can be encoded as printable strings and so accepting a str as a parameter was
+not practical since mtbl is used, frequently, to store arbitrary byte data.
+
+Scripts that used ord() to determine the value of a byte in a buffer returned
+by this module under Python 2 will now need to test the data type. 
+
+For example, in pymtbl<=0.4.0 you might have written:
+
+```
+x = mtbl.varint_encode(1234)
+first_byte = ord(x[0])
+```
+
+Now you would write:
+
+```
+x = mtbl.varint_encode(1234)
+if type(first_type) == str:  # py2
+    first_byte = ord(x[0])
+else:                        # py3
+    first_byte = x[0]
+```
+
+Additionally, you must now pass in bytes to functions like
+varint_encode and writer. Previously, you were able to write either
+`w['key1'] = 'val1'` or `w[b'key1'] = b'val1'` because of Python 2's 
+definition of bytes == str. Now you must write either
+
+ `w[b'key1'] = b'val1'` 
+ 
+ `w['key1'.encode()] = 'val1'.encode()`
+
+While `w['key1'] = 'val1'` will continue to work when using Python 2, it will
+*not* work when using Python 3 and so to maximize portability of your scripts, you 
+should avoid that form.
+
+If you intend to store strings, you should call encode() to ensure they
+are stored with an encoding that you define.
+
+References
+----------
+
+https://candide-guevara.github.io/article/python/2018/02/28/cython-memory-mgt.html
+https://github.com/cython/cython/blob/master/tests/run/bytearray_coercion.pyx
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pymtbl (1.0.0) unstable; urgency=medium
+
+  * Add Python3 compatibility
+  * Add unit tests
+
+ -- Farsight Security, Inc. <software@fsi.io>  Mon, 21 Jan 2019 19:44:02 +0000
+
 pymtbl (0.4.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,6 @@
 
 %:
 	dh $@ --with python2
+
+override_dh_auto_test:
+	python -m unittest discover

--- a/examples/pymtbl_make_random_table.py
+++ b/examples/pymtbl_make_random_table.py
@@ -45,19 +45,19 @@ def main(fname, num_keys):
             last_secs = b - last
             last = b
             sys.stderr.write('wrote %s entries (%s MB) in %s seconds, %s entries/second\n' % (
-                locale.format('%d', total, grouping=True),
-                locale.format('%d', total_bytes / megabyte, grouping=True),
-                locale.format('%f', last_secs, grouping=True),
-                locale.format('%d', report_interval / last_secs, grouping=True)
+                locale.format_string('%d', total, grouping=True),
+                locale.format_string('%d', total_bytes / megabyte, grouping=True),
+                locale.format_string('%f', last_secs, grouping=True),
+                locale.format_string('%d', report_interval / last_secs, grouping=True)
                 )
             )
     b = time.time()
     total_secs = b - a
     sys.stderr.write('wrote %s total entries (%s MB) in %s seconds, %s entries/second\n' % (
-        locale.format('%d', total, grouping=True),
-        locale.format('%d', total_bytes / megabyte, grouping=True),
-        locale.format('%f', total_secs, grouping=True),
-        locale.format('%d', total / total_secs, grouping=True)
+        locale.format_string('%d', total, grouping=True),
+        locale.format_string('%d', total_bytes / megabyte, grouping=True),
+        locale.format_string('%f', total_secs, grouping=True),
+        locale.format_string('%d', total / total_secs, grouping=True)
         )
     )
 

--- a/examples/pymtbl_make_random_table.py
+++ b/examples/pymtbl_make_random_table.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python
-
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import locale
 import random
 import string
@@ -10,6 +22,7 @@ import mtbl
 
 report_interval = 10000000
 megabyte = 1048576.0
+
 
 def main(fname, num_keys):
     writer = mtbl.writer(fname, compression=mtbl.COMPRESSION_SNAPPY)
@@ -23,8 +36,8 @@ def main(fname, num_keys):
         count += 1
         if random.random() >= 0.5:
             total += 1
-            key = '%010d' % count
-            val = random.choice(string.ascii_lowercase) * random.randint(1, 50)
+            key = ('%010d' % count).encode()
+            val = (random.choice(string.ascii_lowercase) * random.randint(1, 50)).encode()
             writer[key] = val
             total_bytes += len(key) + len(val)
         if (count % report_interval) == 0:
@@ -48,9 +61,11 @@ def main(fname, num_keys):
         )
     )
 
+
 def usage():
     sys.stderr.write('Usage: %s <MTBL FILENAME> <MAX NUMBER OF KEYS>\n' % sys.argv[0])
     sys.exit(1)
+
 
 if __name__ == '__main__':
     locale.setlocale(locale.LC_ALL, '')

--- a/examples/pymtbl_make_random_table_2.py
+++ b/examples/pymtbl_make_random_table_2.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import locale
 import random
@@ -11,8 +24,15 @@ import mtbl
 report_interval = 100000
 megabyte = 1048576.0
 
+try:
+    maxint = sys.maxint  # py2
+except:
+    maxint = sys.maxsize  # py3
+
+
 def merge_func(key, val0, val1):
     return val0 + val1
+
 
 def main(fname, num_keys):
     sorter = mtbl.sorter(merge_func)
@@ -24,8 +44,8 @@ def main(fname, num_keys):
     count = 0
     while count < num_keys:
         count += 1
-        key = '%020d' % random.randint(0, sys.maxint)
-        val = random.choice(string.ascii_lowercase) * random.randint(1, 50)
+        key = ('%020d' % random.randint(0, maxint)).encode()
+        val = (random.choice(string.ascii_lowercase) * random.randint(1, 50)).encode()
         sorter[key] = val
         total_bytes += len(key) + len(val)
         if (count % report_interval) == 0:
@@ -51,9 +71,11 @@ def main(fname, num_keys):
         )
     )
 
+
 def usage():
     sys.stderr.write('Usage: %s <MTBL FILENAME> <NUMBER OF KEYS>\n' % sys.argv[0])
     sys.exit(1)
+
 
 if __name__ == '__main__':
     locale.setlocale(locale.LC_ALL, '')

--- a/examples/pymtbl_make_random_table_2.py
+++ b/examples/pymtbl_make_random_table_2.py
@@ -24,10 +24,7 @@ import mtbl
 report_interval = 100000
 megabyte = 1048576.0
 
-try:
-    maxint = sys.maxint  # py2
-except:
-    maxint = sys.maxsize  # py3
+maxint = sys.maxsize
 
 
 def merge_func(key, val0, val1):

--- a/examples/pymtbl_make_random_table_2.py
+++ b/examples/pymtbl_make_random_table_2.py
@@ -50,10 +50,10 @@ def main(fname, num_keys):
             last_secs = b - last
             last = b
             sys.stderr.write('generated %s entries (%s MB) in %s seconds, %s entries/second\n' % (
-                locale.format('%d', count, grouping=True),
-                locale.format('%d', total_bytes / megabyte, grouping=True),
-                locale.format('%f', last_secs, grouping=True),
-                locale.format('%d', report_interval / last_secs, grouping=True)
+                locale.format_string('%d', count, grouping=True),
+                locale.format_string('%d', total_bytes / megabyte, grouping=True),
+                locale.format_string('%f', last_secs, grouping=True),
+                locale.format_string('%d', report_interval / last_secs, grouping=True)
                 )
             )
     sys.stderr.write('writing to output file %s\n' % fname)
@@ -61,10 +61,10 @@ def main(fname, num_keys):
     b = time.time()
     total_secs = b - a
     sys.stderr.write('wrote %s total entries (%s MB) in %s seconds, %s entries/second\n' % (
-        locale.format('%d', count, grouping=True),
-        locale.format('%d', total_bytes / megabyte, grouping=True),
-        locale.format('%f', total_secs, grouping=True),
-        locale.format('%d', count / total_secs, grouping=True)
+        locale.format_string('%d', count, grouping=True),
+        locale.format_string('%d', total_bytes / megabyte, grouping=True),
+        locale.format_string('%f', total_secs, grouping=True),
+        locale.format_string('%d', count / total_secs, grouping=True)
         )
     )
 

--- a/examples/pymtbl_merge_tables.py
+++ b/examples/pymtbl_merge_tables.py
@@ -1,11 +1,25 @@
 #!/usr/bin/env python
-
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import sys
 
 import mtbl
 
+
 def merge_func(key, val0, val1):
-    return val0 + ' ' + val1
+    return val0 + b' ' + val1
+
 
 def main(output_fname, input_fnames):
     merger = mtbl.merger(merge_func)
@@ -17,9 +31,11 @@ def main(output_fname, input_fnames):
         writer[k] = v
     writer.close()
 
+
 def usage():
     sys.stderr.write('Usage: %s <OUTPUT> <INPUT> [<INPUT>...]\n' % sys.argv[0])
     sys.exit(1)
+
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:

--- a/examples/pymtbl_merge_tables_2.py
+++ b/examples/pymtbl_merge_tables_2.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 
 import mtbl
 
+
 def merge_func(key, val0, val1):
-    return val0 + ' ' + val1
+    return val0 + b' ' + val1
+
 
 def main(output_fname, input_fnames):
     merger = mtbl.merger(merge_func)
@@ -16,9 +31,11 @@ def main(output_fname, input_fnames):
     merger.write(writer)
     writer.close()
 
+
 def usage():
     sys.stderr.write('Usage: %s <OUTPUT> <INPUT> [<INPUT>...]\n' % sys.argv[0])
     sys.exit(1)
+
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:

--- a/examples/pymtbl_search_random_table.py
+++ b/examples/pymtbl_search_random_table.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python
-
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import locale
 import random
 import sys
@@ -9,6 +21,7 @@ import mtbl
 
 report_interval = 10000
 
+
 def main(fname, num_keys, num_iters):
     reader = mtbl.reader(fname)
 
@@ -17,7 +30,7 @@ def main(fname, num_keys, num_iters):
     num_found = 0
     count = 0
     while count < num_iters:
-        key = '%010d' % random.randint(0, num_keys)
+        key = ('%010d' % random.randint(0, num_keys)).encode()
         if reader.has_key(key):
             val = reader[key]
             num_found += 1
@@ -43,10 +56,12 @@ def main(fname, num_keys, num_iters):
         )
     )
 
+
 def usage():
     sys.stderr.write('Usage: %s <MTBL FILENAME> <NUMBER OF KEYS> <NUMBER OF ITERATIONS>\n' %
         sys.argv[0])
     sys.exit(1)
+
 
 if __name__ == '__main__':
     locale.setlocale(locale.LC_ALL, '')

--- a/examples/pymtbl_search_random_table.py
+++ b/examples/pymtbl_search_random_table.py
@@ -40,19 +40,19 @@ def main(fname, num_keys, num_iters):
             last_secs = b - last
             last = b
             sys.stderr.write('%s lookups, %s keys found in %s seconds, %s lookups/second\n' % (
-                locale.format('%d', count, grouping=True),
-                locale.format('%d', num_found, grouping=True),
-                locale.format('%f', last_secs, grouping=True),
-                locale.format('%d', report_interval / last_secs, grouping=True)
+                locale.format_string('%d', count, grouping=True),
+                locale.format_string('%d', num_found, grouping=True),
+                locale.format_string('%f', last_secs, grouping=True),
+                locale.format_string('%d', report_interval / last_secs, grouping=True)
                 )
             )
     b = time.time()
     total_secs = b - a
     sys.stderr.write('%s total lookups, %s keys found in %s seconds, %s lookups/second\n' % (
-        locale.format('%d', count, grouping=True),
-        locale.format('%d', num_found, grouping=True),
-        locale.format('%f', total_secs, grouping=True),
-        locale.format('%d', count / total_secs, grouping=True)
+        locale.format_string('%d', count, grouping=True),
+        locale.format_string('%d', num_found, grouping=True),
+        locale.format_string('%f', total_secs, grouping=True),
+        locale.format_string('%d', count / total_secs, grouping=True)
         )
     )
 

--- a/examples/wf/Makefile
+++ b/examples/wf/Makefile
@@ -4,7 +4,6 @@ BOOK_FILES = $(foreach ebook,$(EBOOKS),$(ebook).txt)
 MTBL_FILES = $(foreach ebook,$(EBOOKS),$(ebook).mtbl)
 
 %.txt:
-	echo $@
 	@wget -O $@ http://www.gutenberg.org/files/$(shell basename $@ .txt)/$(shell basename $@ .txt)-0.txt
 
 %.mtbl: %.txt

--- a/examples/wf/Makefile
+++ b/examples/wf/Makefile
@@ -4,7 +4,8 @@ BOOK_FILES = $(foreach ebook,$(EBOOKS),$(ebook).txt)
 MTBL_FILES = $(foreach ebook,$(EBOOKS),$(ebook).mtbl)
 
 %.txt:
-	@wget -O $@ http://www.gutenberg.org/files/$(shell basename $@ .txt)/$@
+	echo $@
+	@wget -O $@ http://www.gutenberg.org/files/$(shell basename $@ .txt)/$(shell basename $@ .txt)-0.txt
 
 %.mtbl: %.txt
 	rm -f $@

--- a/examples/wf/pymtbl_wf_analyze.py
+++ b/examples/wf/pymtbl_wf_analyze.py
@@ -42,7 +42,11 @@ def main(txt_fname, mtbl_fname):
            line.startswith('*** END OF THIS PROJECT GUTENBERG EBOOK'):
             break
         for tok in line.strip().split():
-            word = tok.strip(string.punctuation).lower().encode()
+            try:
+                word = tok.strip(string.punctuation).lower().encode()
+            except UnicodeDecodeError:
+                # Don't need to encode() in py2 becase 'str' is a synonym for 'bytes' so we can already use it as a key
+                word = tok.strip(string.punctuation).lower() #py2
             sorter[word] = mtbl.varint_encode(1)
 
     sorter.write(writer)

--- a/examples/wf/pymtbl_wf_analyze.py
+++ b/examples/wf/pymtbl_wf_analyze.py
@@ -1,14 +1,28 @@
 #!/usr/bin/env python
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import string
 import sys
-
 import mtbl
+
 
 def merge_func(key, val0, val1):
     i0 = mtbl.varint_decode(val0)
     i1 = mtbl.varint_decode(val1)
     return mtbl.varint_encode(i0 + i1)
+
 
 def main(txt_fname, mtbl_fname):
     txt = open(txt_fname)
@@ -28,10 +42,11 @@ def main(txt_fname, mtbl_fname):
            line.startswith('*** END OF THIS PROJECT GUTENBERG EBOOK'):
             break
         for tok in line.strip().split():
-            word = tok.strip(string.punctuation).lower()
+            word = tok.strip(string.punctuation).lower().encode()
             sorter[word] = mtbl.varint_encode(1)
 
     sorter.write(writer)
+
 
 if __name__ == '__main__':
     if not len(sys.argv) == 3:

--- a/examples/wf/pymtbl_wf_dump.py
+++ b/examples/wf/pymtbl_wf_dump.py
@@ -23,7 +23,7 @@ def main(mtbl_fname):
     for k, v in reader.items():
         word = k
         count = mtbl.varint_decode(v)
-        print('%s\t%s' % (count, word.decode()))
+        print('%s\t%s' % (count, word))
 
 
 if __name__ == '__main__':

--- a/examples/wf/pymtbl_wf_dump.py
+++ b/examples/wf/pymtbl_wf_dump.py
@@ -1,16 +1,30 @@
 #!/usr/bin/env python
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-import string
+from __future__ import print_function
 import sys
-
 import mtbl
+
 
 def main(mtbl_fname):
     reader = mtbl.reader(mtbl_fname)
     for k, v in reader.items():
         word = k
         count = mtbl.varint_decode(v)
-        print '%s\t%s' % (count, word)
+        print('%s\t%s' % (count, word.decode()))
+
 
 if __name__ == '__main__':
     if not len(sys.argv) == 2:

--- a/examples/wf/pymtbl_wf_merge.py
+++ b/examples/wf/pymtbl_wf_merge.py
@@ -1,15 +1,27 @@
 #!/usr/bin/env python
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-import string
-import struct
 import sys
-
 import mtbl
+
 
 def merge_func(key, val0, val1):
     i0 = mtbl.varint_decode(val0)
     i1 = mtbl.varint_decode(val1)
     return mtbl.varint_encode(i0 + i1)
+
 
 def main(input_fnames, output_fname):
     merger = mtbl.merger(merge_func)
@@ -18,6 +30,7 @@ def main(input_fnames, output_fname):
         reader = mtbl.reader(fname)
         merger.add_reader(reader)
     merger.write(writer)
+
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:

--- a/mtbl.pxi
+++ b/mtbl.pxi
@@ -1,3 +1,16 @@
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 cimport cython
 from cpython cimport bool
 from cpython.string cimport *

--- a/mtbl.pyx
+++ b/mtbl.pyx
@@ -1,3 +1,18 @@
+#cython: embedsignature=True
+#cython: language_level=2
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 include "mtbl.pxi"
 import threading
 
@@ -31,12 +46,15 @@ def varint_length(uint64_t value):
     """varint_length(v) -> number of bytes the integer v would require in varint encoding."""
     return mtbl_varint_length(value)
 
-def varint_length_packed(bytes py_buf):
+def varint_length_packed(py_buf):
     """varint_length_packed(b) -> number of varint-packed bytes at the start of b."""
     cdef uint8_t *buf
     cdef Py_ssize_t len_buf
     cdef size_t sz
-    PyString_AsStringAndSize(py_buf, <char **> &buf, &len_buf)
+    len_buf = len(py_buf)
+    if type(py_buf) == bytearray or type(py_buf) == str:
+        py_buf = bytes(py_buf)
+    buf = py_buf
     with nogil:
         sz = mtbl_varint_length_packed(buf, len_buf)
     if sz == 0:
@@ -49,15 +67,21 @@ def varint_encode(long v):
     cdef size_t sz
     with nogil:
         sz = mtbl_varint_encode64(buf, v)
-    return PyString_FromStringAndSize(<char *> buf, sz)
+    rv = buf[:sz]
+    return <bytes> buf[:sz]
 
-def varint_decode(bytes py_buf):
+def varint_decode(py_buf):
     """varint_decode(b) -> decode variable-width packed integer from b"""
     cdef uint64_t val
-    cdef uint8_t *buf
+    cdef const uint8_t *buf
     cdef Py_ssize_t len_buf
     cdef size_t bytes_read
-    PyString_AsStringAndSize(py_buf, <char **> &buf, &len_buf)
+
+    if type(py_buf) == bytearray or type(py_buf) == str:
+        py_buf = bytes(py_buf)
+
+    buf = <uint8_t *> py_buf
+    len_buf = len(py_buf)
     if mtbl_varint_length_packed(buf, len_buf) == 0:
         raise VarintDecodingError
     with nogil:
@@ -84,8 +108,8 @@ cdef class iterkeys(object):
 
     def __next__(self):
         cdef mtbl_res res
-        cdef uint8_t *key
-        cdef uint8_t *val
+        cdef const uint8_t *key
+        cdef const uint8_t *val
         cdef size_t len_key
         cdef size_t len_val
 
@@ -96,7 +120,7 @@ cdef class iterkeys(object):
             res = mtbl_iter_next(self._instance, &key, &len_key, &val, &len_val)
         if res == mtbl_res_failure:
             raise StopIteration
-        return PyString_FromStringAndSize(<char *> key, len_key)
+        return <bytes> key[:len_key]
 
 @cython.internal
 cdef class itervalues(object):
@@ -118,8 +142,8 @@ cdef class itervalues(object):
 
     def __next__(self):
         cdef mtbl_res res
-        cdef uint8_t *key
-        cdef uint8_t *val
+        cdef const uint8_t *key
+        cdef const uint8_t *val
         cdef size_t len_key
         cdef size_t len_val
 
@@ -130,7 +154,7 @@ cdef class itervalues(object):
             res = mtbl_iter_next(self._instance, &key, &len_key, &val, &len_val)
         if res == mtbl_res_failure:
             raise StopIteration
-        return PyString_FromStringAndSize(<char *> val, len_val)
+        return <bytes> val[:len_val]
 
 @cython.internal
 cdef class iteritems(object):
@@ -152,8 +176,8 @@ cdef class iteritems(object):
 
     def __next__(self):
         cdef mtbl_res res
-        cdef uint8_t *key
-        cdef uint8_t *val
+        cdef const uint8_t *key
+        cdef const uint8_t *val
         cdef size_t len_key
         cdef size_t len_val
 
@@ -166,8 +190,7 @@ cdef class iteritems(object):
         if res == mtbl_res_failure:
             raise StopIteration
 
-        return (PyString_FromStringAndSize(<char *> key, len_key),
-                PyString_FromStringAndSize(<char *> val, len_val))
+        return (<bytes> key[:len_key], <bytes> val[:len_val])
 
 cdef get_iterkeys(parent, mtbl_iter *instance):
     it = iterkeys(parent)
@@ -240,13 +263,15 @@ cdef class reader(DictMixin):
         with nogil:
             mtbl_reader_destroy(&self._instance)
 
-    def __init__(self, char * fname, bool verify_checksums=False):
+    def __init__(self, str fname, bool verify_checksums=False):
         cdef mtbl_reader_options *opt
+        cdef bytes tfn_bytes = fname.encode()
+        cdef char *tfn = tfn_bytes
 
         with nogil:
             opt = mtbl_reader_options_init()
             mtbl_reader_options_set_verify_checksums(opt, verify_checksums)
-            self._instance = mtbl_reader_init(fname, opt)
+            self._instance = mtbl_reader_init(tfn, opt)
             mtbl_reader_options_destroy(&opt)
 
         if (self._instance == NULL):
@@ -298,17 +323,19 @@ cdef class reader(DictMixin):
         between key0 and key1 inclusive.
         """
         cdef mtbl_res res
-        cdef uint8_t *key0
-        cdef uint8_t *key1
+        cdef const uint8_t *key0
+        cdef const uint8_t *key1
         cdef size_t len_key0
         cdef size_t len_key1
 
         self.check_initialized()
 
-        key0 = <uint8_t *> PyString_AsString(py_key0)
-        key1 = <uint8_t *> PyString_AsString(py_key1)
-        len_key0 = PyString_Size(py_key0)
-        len_key1 = PyString_Size(py_key1)
+        t = py_key0
+        key0 = <uint8_t *> t
+        t = py_key1
+        key1 = <uint8_t *> t
+        len_key0 = len(py_key0)
+        len_key1 = len(py_key1)
 
         return get_iteritems(self, mtbl_source_get_range(
             mtbl_reader_source(self._instance), key0, len_key0, key1, len_key1))
@@ -319,13 +346,14 @@ cdef class reader(DictMixin):
         begins with key_prefix.
         """
         cdef mtbl_res res
-        cdef uint8_t *key
+        cdef const uint8_t *key
         cdef size_t len_key
 
         self.check_initialized()
 
-        key = <uint8_t *> PyString_AsString(py_key)
-        len_key = PyString_Size(py_key)
+        t = py_key
+        key = <uint8_t *> t
+        len_key = len(py_key)
 
         return get_iteritems(self, mtbl_source_get_prefix(
             mtbl_reader_source(self._instance), key, len_key))
@@ -333,15 +361,16 @@ cdef class reader(DictMixin):
     def __getitem__(self, bytes py_key):
         cdef mtbl_iter *it
         cdef mtbl_res res
-        cdef uint8_t *key
-        cdef uint8_t *val
+        cdef const uint8_t *key
+        cdef const uint8_t *val
         cdef size_t len_key
         cdef size_t len_val
 
         self.check_initialized()
 
-        key = <uint8_t *> PyString_AsString(py_key)
-        len_key = PyString_Size(py_key)
+        t = py_key
+        key = <uint8_t *> t
+        len_key = len(py_key)
 
         items = []
         with nogil:
@@ -353,7 +382,7 @@ cdef class reader(DictMixin):
                 res = mtbl_iter_next(it, &key, &len_key, &val, &len_val)
             if res == mtbl_res_failure:
                 break
-            items.append(PyString_FromStringAndSize(<char *> val, len_val))
+            items.append(val[:len_val])
         with nogil:
             mtbl_iter_destroy(&it)
         if not items:
@@ -380,7 +409,7 @@ cdef class writer(object):
             mtbl_writer_destroy(&self._instance)
 
     def __init__(self,
-            char * fname,
+            str fname,
             mtbl_compression_type compression=COMPRESSION_NONE,
             size_t block_size=8192,
             size_t block_restart_interval=16):
@@ -393,13 +422,16 @@ cdef class writer(object):
 
         self._lock = threading.Semaphore()
 
+        cdef bytes tfn_bytes = fname.encode()
+        cdef char *tfn = tfn_bytes
         cdef mtbl_writer_options *opt
+
         with nogil:
             opt = mtbl_writer_options_init()
             mtbl_writer_options_set_compression(opt, compression)
             mtbl_writer_options_set_block_size(opt, block_size)
             mtbl_writer_options_set_block_restart_interval(opt, block_restart_interval)
-            self._instance = mtbl_writer_init(fname, opt)
+            self._instance = mtbl_writer_init(tfn, opt)
             mtbl_writer_options_destroy(&opt)
         if self._instance == NULL:
             raise IOError("unable to initialize file: '%s'" % fname)
@@ -410,7 +442,7 @@ cdef class writer(object):
             with nogil:
                 mtbl_writer_destroy(&self._instance)
 
-    def __setitem__(self, bytes py_key, bytes py_val):
+    def __setitem__(self, py_key, py_val):
         """
         W.__setitem__(key, value) <==> W[key] = value
 
@@ -419,18 +451,23 @@ cdef class writer(object):
         written key.
         """
         cdef mtbl_res res
-        cdef uint8_t *key
-        cdef uint8_t *val
+        cdef const uint8_t *key
+        cdef const uint8_t *val
         cdef size_t len_key
         cdef size_t len_val
 
         if self._instance == NULL:
             raise TableClosedException
 
-        key = <uint8_t *> PyString_AsString(py_key)
-        val = <uint8_t *> PyString_AsString(py_val)
-        len_key = PyString_Size(py_key)
-        len_val = PyString_Size(py_val)
+        if type(py_key) == bytearray or type(py_key) == str:
+            py_key = bytes(py_key)
+        if type(py_val) == bytearray or type(py_val) == str:
+            py_val = bytes(py_val)
+
+        key = <uint8_t *> py_key
+        val = <uint8_t *> py_val
+        len_key = len(py_key)
+        len_val = len(py_val)
 
         with self._lock:
             with nogil:
@@ -448,17 +485,19 @@ cdef void merge_func_wrapper(void *clos,
         uint8_t *val0, size_t len_val0,
         uint8_t *val1, size_t len_val1,
         uint8_t **merged_val, size_t *len_merged_val) with gil:
-    cdef str py_key
-    cdef str py_val0
-    cdef str py_val1
-    cdef str py_merged_val
-    py_key = PyString_FromStringAndSize(<char *> key, len_key)
-    py_val0 = PyString_FromStringAndSize(<char *> val0, len_val0)
-    py_val1 = PyString_FromStringAndSize(<char *> val1, len_val1)
+    cdef bytes py_key
+    cdef bytes py_val0
+    cdef bytes py_val1
+    cdef bytes py_merged_val
+    py_key = key[:len_key]
+    py_val0 = val0[:len_val0]
+    py_val1 = val1[:len_val1]
+
     py_merged_val = (<object> clos)(py_key, py_val0, py_val1)
-    len_merged_val[0] = <size_t> PyString_Size(py_merged_val)
+    len_merged_val[0] = <size_t> len(py_merged_val)
     merged_val[0] = <uint8_t *> malloc(len_merged_val[0])
-    memcpy(merged_val[0], PyString_AsString(py_merged_val), len_merged_val[0])
+    t = py_merged_val
+    memcpy(merged_val[0], <uint8_t *>py_merged_val, len_merged_val[0])
 
 cdef class merger(object):
     """
@@ -531,11 +570,12 @@ cdef class merger(object):
         M.get(key) -> an iterator over all (key, value) items in M which match key.
         """
         cdef mtbl_res res
-        cdef uint8_t *key
+        cdef const uint8_t *key
         cdef size_t len_key
 
-        key = <uint8_t *> PyString_AsString(py_key)
-        len_key = PyString_Size(py_key)
+        t = py_key
+        key = <uint8_t *> t
+        len_key = len(py_key)
 
         return get_iteritems(self,
                 mtbl_source_get(mtbl_merger_source(self._instance), key, len_key))
@@ -546,15 +586,17 @@ cdef class merger(object):
         between key0 and key1 inclusive.
         """
         cdef mtbl_res res
-        cdef uint8_t *key0
-        cdef uint8_t *key1
+        cdef const uint8_t *key0
+        cdef const uint8_t *key1
         cdef size_t len_key0
         cdef size_t len_key1
 
-        key0 = <uint8_t *> PyString_AsString(py_key0)
-        key1 = <uint8_t *> PyString_AsString(py_key1)
-        len_key0 = PyString_Size(py_key0)
-        len_key1 = PyString_Size(py_key1)
+        t = py_key0
+        key0 = <uint8_t *> t
+        t = py_key1
+        key1 = <uint8_t *> t
+        len_key0 = len(py_key0)
+        len_key1 = len(py_key1)
 
         return get_iteritems(self, mtbl_source_get_range(
             mtbl_merger_source(self._instance), key0, len_key0, key1, len_key1))
@@ -565,11 +607,12 @@ cdef class merger(object):
         begins with key_prefix.
         """
         cdef mtbl_res res
-        cdef uint8_t *key
+        cdef const uint8_t *key
         cdef size_t len_key
 
-        key = <uint8_t *> PyString_AsString(py_key)
-        len_key = PyString_Size(py_key)
+        t = py_key
+        key = <uint8_t *> t
+        len_key = len(py_key)
 
         return get_iteritems(self, mtbl_source_get_prefix(
             mtbl_merger_source(self._instance), key, len_key))
@@ -600,7 +643,7 @@ cdef class sorter(object):
 
     def __init__(self,
                  object merge_func,
-                 bytes temp_dir=DEFAULT_SORTER_TEMP_DIR,
+                 str temp_dir=DEFAULT_SORTER_TEMP_DIR,
                  size_t max_memory=DEFAULT_SORTER_MEMORY):
         cdef mtbl_sorter_options *opt
         self._lock = threading.Semaphore()
@@ -612,7 +655,7 @@ cdef class sorter(object):
                                            <mtbl_merge_func> merge_func_wrapper,
                                            <void *> merge_func)
 
-        mtbl_sorter_options_set_temp_dir(opt, temp_dir)
+        mtbl_sorter_options_set_temp_dir(opt, temp_dir.encode('UTF-8'))
         mtbl_sorter_options_set_max_memory(opt, max_memory)
         with nogil:
             self._instance = mtbl_sorter_init(opt)
@@ -628,7 +671,7 @@ cdef class sorter(object):
         if res != mtbl_res_success:
             raise RuntimeError
 
-    def __setitem__(self, bytes py_key, bytes py_val):
+    def __setitem__(self, py_key, py_val):
         """
         S.__setitem__(key, value) <==> S[key] = value
 
@@ -637,18 +680,25 @@ cdef class sorter(object):
         conflicting values.
         """
         cdef mtbl_res res
-        cdef uint8_t *key
-        cdef uint8_t *val
+        cdef const uint8_t *key
+        cdef const uint8_t *val
         cdef size_t len_key
         cdef size_t len_val
 
         if self._instance == NULL:
             raise RuntimeError
 
-        key = <uint8_t *> PyString_AsString(py_key)
-        val = <uint8_t *> PyString_AsString(py_val)
-        len_key = PyString_Size(py_key)
-        len_val = PyString_Size(py_val)
+        if type(py_key) == bytearray or type(py_key) == str:
+            py_key = bytes(py_key)
+        if type(py_val) == bytearray or type(py_val) == str:
+            py_val = bytes(py_val)
+
+        t = py_key
+        key = <uint8_t *> t
+        t = py_val
+        val = <uint8_t *> t
+        len_key = len(py_key)
+        len_val = len(py_val)
 
         with self._lock:
             with nogil:

--- a/mtbl.pyx
+++ b/mtbl.pyx
@@ -265,7 +265,7 @@ cdef class reader(DictMixin):
 
     def __init__(self, str fname, bool verify_checksums=False):
         cdef mtbl_reader_options *opt
-        cdef bytes tfn_bytes = fname.encode()
+        cdef bytes tfn_bytes = fname.encode('utf-8')
         cdef char *tfn = tfn_bytes
 
         with nogil:
@@ -422,7 +422,7 @@ cdef class writer(object):
 
         self._lock = threading.Semaphore()
 
-        cdef bytes tfn_bytes = fname.encode()
+        cdef bytes tfn_bytes = fname.encode('utf-8')
         cdef char *tfn = tfn_bytes
         cdef mtbl_writer_options *opt
 
@@ -655,7 +655,7 @@ cdef class sorter(object):
                                            <mtbl_merge_func> merge_func_wrapper,
                                            <void *> merge_func)
 
-        mtbl_sorter_options_set_temp_dir(opt, temp_dir.encode('UTF-8'))
+        mtbl_sorter_options_set_temp_dir(opt, temp_dir.encode('utf-8'))
         mtbl_sorter_options_set_max_memory(opt, max_memory)
         with nogil:
             self._instance = mtbl_sorter_init(opt)

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@
 NAME = 'pymtbl'
 VERSION = '0.4.1'
 
-from distutils.core import setup
+from distutils.core import setup, Command
 from distutils.extension import Extension
+import unittest
 
 def pkgconfig(*packages, **kw):
     import subprocess
@@ -21,13 +22,30 @@ def pkgconfig(*packages, **kw):
             kw.setdefault(flag_map[flag], []).append(arg)
     return kw
 
+
+class Test(Command):
+    user_options = []
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        unittest.TextTestRunner(verbosity=1).run(
+            unittest.TestLoader().discover('.'))
+
+
 try:
     from Cython.Distutils import build_ext
     setup(
         name = NAME,
         version = VERSION,
         ext_modules = [ Extension('mtbl', ['mtbl.pyx'], **pkgconfig('libmtbl >= 1.1.0')) ],
-        cmdclass = {'build_ext': build_ext},
+        cmdclass = {
+            'build_ext': build_ext,
+            'test': Test,
+        },
     )
 except ImportError:
     import os

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,20 @@
 #!/usr/bin/env python
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 NAME = 'pymtbl'
-VERSION = '0.4.1'
+VERSION = '1.0.0'
 
 from distutils.core import setup, Command
 from distutils.extension import Extension
@@ -14,8 +27,18 @@ def pkgconfig(*packages, **kw):
             '-L': 'library_dirs',
             '-l': 'libraries'
     }
-    pkg_config_cmd = 'pkg-config --cflags --libs "%s"' % ' '.join(packages)
-    for token in subprocess.check_output(pkg_config_cmd, shell=True).split():
+
+    pkg_config_cmd = (
+        'pkg-config',
+        '--cflags',
+        '--libs',
+        ' '.join(packages),
+    )
+
+    pkg_config_output = subprocess.check_output(pkg_config_cmd,
+                                                universal_newlines=True)
+
+    for token in pkg_config_output.split():
         flag = token[:2]
         arg = token[2:]
         if flag in flag_map:
@@ -53,7 +76,7 @@ except ImportError:
         setup(
             name = NAME,
             version = VERSION,
-            ext_modules = [ Extension('mtbl', ['mtbl.c'], **pkgconfig('libmtbl >= 0.8.0')) ],
+            ext_modules = [ Extension('mtbl', ['mtbl.c'], **pkgconfig('libmtbl >= 1.1.0')) ],
         )
     else:
         raise

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,12 @@
+
+import os
+import unittest
+
+import mtbl
+
+
+def write_mtbl(filename, tuples):
+    writer = mtbl.writer(filename, compression=mtbl.COMPRESSION_NONE)
+    for k, v in tuples:
+        writer[k] = v
+    writer.close()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,16 @@
-
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import unittest
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,3 +10,14 @@ def write_mtbl(filename, tuples):
     for k, v in tuples:
         writer[k] = v
     writer.close()
+
+
+class MtblTestCase(unittest.TestCase):
+
+    def write_mtbl(self, filename, tuples):
+        # tempfiles would be better but mtbl is bossy about fds :/ (?)
+        filepath = os.path.join(
+            os.path.dirname(__file__), filename)
+        write_mtbl(filepath, tuples)
+        self.addCleanup(os.remove, filepath)
+        return filepath

--- a/tests/test_from_bytes.py
+++ b/tests/test_from_bytes.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015-2021 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import unittest
+import sys
+
+import mtbl
+
+class StrFromBytesTestCase(unittest.TestCase):
+
+    def test_from_bytes_with_byte_string(self):
+        expected = 'foobar'
+        actual = mtbl.from_bytes(expected.encode('utf-8'))
+        self.assertEqual(actual, expected)
+    
+    @unittest.skipIf(sys.version_info[0] >= 3, 'py3 can handle unicode')
+    def test_from_bytes_with_nonascii_byte_string(self):
+        expected = '\xe4\xbd\xa0\xe5\xa5\xbd'
+        actual = mtbl.from_bytes(u'你好'.encode('utf-8'))
+        self.assertEqual(actual, expected)
+    
+    @unittest.skipIf(sys.version_info[0] == 2, 'py2 can\'t handle unicode')
+    def test_from_bytes_with_nonascii_byte_string(self):
+        expected = '你好'
+        actual = mtbl.from_bytes(expected.encode('utf-8'))
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_non_string(self):
+        expected = b'\x90N'
+        actual = mtbl.from_bytes(expected)
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_non_string2(self):
+        expected = b'\xc4\xb8\xd30\x00\x00\x00'
+        actual = mtbl.from_bytes(expected)
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_deadbeef(self):
+        expected = b'\xde\xad\xbe\xef'
+        actual = mtbl.from_bytes(expected)
+        self.assertEqual(actual, expected)
+
+    def test_from_bytes_with_128(self):
+        expected = b'\x80\x01' # b'\x80\x01' == mtbl.varint_encode(128)
+        actual = mtbl.from_bytes(expected)
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_byte_string_as_bytes(self):
+        expected = b'foobar'
+        actual = mtbl.from_bytes(expected, True)
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_byte_string_as_bytes2(self):
+        expected = b'\x01'
+        actual = mtbl.from_bytes(expected, True)
+        self.assertEqual(actual, expected)

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -1,6 +1,5 @@
 
 import os
-import unittest
 
 import mtbl
 from . import MtblTestCase

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -1,0 +1,62 @@
+
+import os
+import unittest
+
+import mtbl
+from . import write_mtbl
+
+
+def merge_func(key, val0, val1):
+    return val0 + ' ' + val1
+
+
+class MergerTestCase(unittest.TestCase):
+
+    def write_mtbl(self, filename, tuples):
+        # tempfiles would be better but mtbl is bossy about fds :/ (?)
+        filepath = os.path.join(
+            os.path.dirname(__file__), filename)
+        write_mtbl(filepath, tuples)
+        self.addCleanup(os.remove, filepath)
+        return filepath
+
+    def setUp(self):
+        super(MergerTestCase, self).setUp()
+        # write two mtbls to be merged
+        self.mtbls_to_merge = []
+        for filename, tuples in [
+                ('left.mtbl',
+                 [('key1', 'val1'), ('key2', 'val2'), ('key3', 'val3')]),
+                ('right.mtbl',
+                 [('key17', 'val17'), ('key23', 'val23'), ('key4', 'val4')]),
+        ]:
+            mtbl = self.write_mtbl(filename, tuples)
+            self.mtbls_to_merge.append(mtbl)
+
+    def test_merge_and_iteritems(self):
+        merger = mtbl.merger(merge_func)
+        merged_filename = os.path.join(
+            os.path.dirname(__file__), 'merged.mtbl')
+        writer = mtbl.writer(
+            merged_filename, compression=mtbl.COMPRESSION_NONE)
+        self.addCleanup(os.remove, merged_filename)
+        # write a merged mtbl
+        for filename in self.mtbls_to_merge:
+            merger.add_reader(mtbl.reader(filename))
+        for k, v in merger.iteritems():
+            writer[k] = v
+        writer.close()
+        # check our results
+        reader = mtbl.reader(merged_filename, verify_checksums=True)
+        result = list(reader.iteritems())
+        self.assertEqual(
+            [
+                ('key1', 'val1'),
+                ('key17', 'val17'),
+                ('key2', 'val2'),
+                ('key23', 'val23'),
+                ('key3', 'val3'),
+                ('key4', 'val4'),
+            ],
+            result,
+        )

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -3,22 +3,14 @@ import os
 import unittest
 
 import mtbl
-from . import write_mtbl
+from . import MtblTestCase
 
 
 def merge_func(key, val0, val1):
     return val0 + ' ' + val1
 
 
-class MergerTestCase(unittest.TestCase):
-
-    def write_mtbl(self, filename, tuples):
-        # tempfiles would be better but mtbl is bossy about fds :/ (?)
-        filepath = os.path.join(
-            os.path.dirname(__file__), filename)
-        write_mtbl(filepath, tuples)
-        self.addCleanup(os.remove, filepath)
-        return filepath
+class MergerTestCase(MtblTestCase):
 
     def setUp(self):
         super(MergerTestCase, self).setUp()

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -1,4 +1,16 @@
-
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 
 import mtbl
@@ -17,9 +29,9 @@ class MergerTestCase(MtblTestCase):
         self.mtbls_to_merge = []
         for filename, tuples in [
                 ('left.mtbl',
-                 [('key1', 'val1'), ('key2', 'val2'), ('key3', 'val3')]),
+                 [(b'key1', b'val1'), (b'key2', b'val2'), (b'key3', b'val3')]),
                 ('right.mtbl',
-                 [('key17', 'val17'), ('key23', 'val23'), ('key4', 'val4')]),
+                 [(b'key17', b'val17'), (b'key23', b'val23'), (b'key4', b'val4')]),
         ]:
             mtbl = self.write_mtbl(filename, tuples)
             self.mtbls_to_merge.append(mtbl)
@@ -42,12 +54,12 @@ class MergerTestCase(MtblTestCase):
         result = list(reader.iteritems())
         self.assertEqual(
             [
-                ('key1', 'val1'),
-                ('key17', 'val17'),
-                ('key2', 'val2'),
-                ('key23', 'val23'),
-                ('key3', 'val3'),
-                ('key4', 'val4'),
+                (b'key1', b'val1'),
+                (b'key17', b'val17'),
+                (b'key2', b'val2'),
+                (b'key23', b'val23'),
+                (b'key3', b'val3'),
+                (b'key4', b'val4'),
             ],
             result,
         )

--- a/tests/test_reader_writer.py
+++ b/tests/test_reader_writer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2015-2019 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,54 +25,219 @@ class WriterTestCase(unittest.TestCase):
             os.path.dirname(__file__), 'example.mtbl')
         writer = mtbl.writer(filepath, compression=mtbl.COMPRESSION_NONE)
         self.addCleanup(os.remove, filepath)
-        writer[b'key1'] = b'val1'
-        writer[b'key17'] = b'val17'
-        writer[b'key2'] = b'val2'
-        writer[b'key23'] = b'val23'
+        writer[b'key1'] = 'val1'
+        writer['key17'] = b'val17'
+        writer['key2'] = 'val2'
+        writer['key23'] = 'val23'
         writer[b'key3'] = b'val3'
         writer[b'key4'] = b'val4'
         with self.assertRaises(mtbl.KeyOrderError):
+            writer['key05'] = 'val05'
+        with self.assertRaises(mtbl.KeyOrderError):
             writer[b'key05'] = b'val05'
+        # this one should not raise mtbl.KeyOrderError
+        writer['key5'] = 'key5'
 
 
 class ReaderTestCase(unittest.TestCase):
 
     def setUp(self):
-        super(ReaderTestCase, self).setUp()
         # write our test mtbl
         self.filepath = os.path.join(
             os.path.dirname(__file__), 'example.mtbl')
         writer = mtbl.writer(self.filepath, compression=mtbl.COMPRESSION_NONE)
         self.addCleanup(os.remove, self.filepath)
+        
+        writer[b'\x00'] = b'\x01'
+        writer[b'\x61'] = b'a'
+        writer['key0'] = b'\xff'
         writer[b'key1'] = b'val1'
         writer[b'key17'] = b'val17'
         writer[b'key2'] = b'val2'
         writer[b'key23'] = b'val23'
         writer[b'key3'] = b'val3'
-        writer[b'key4'] = b'val4'
+        writer[b'\x90N'] = b'\xaa'
+        writer['你好，世界'] = 'hello world'
         writer.close()
 
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True)
+    
+    def test_has_key_true(self):
+        self.assertTrue(self.reader.has_key('a'))
+        self.assertTrue(self.reader.has_key(b'\x61'))
+        self.assertTrue(self.reader.has_key('key17'))
+        self.assertTrue(self.reader.has_key(b'key17'))
+    
+    def test_has_key_false(self):        
+        self.assertFalse(self.reader.has_key('key42'))
+        self.assertFalse(self.reader.has_key(b'key42'))
+        self.assertFalse(self.reader.has_key('nope'))
+    
+    def test_get(self):        
+        self.assertEqual(self.reader.get('你好，世界'), ['hello world'])
+        self.assertEqual(self.reader.get('a'), ['a'])
+        self.assertEqual(self.reader.get(b'\x61'), ['a'])   
+        self.assertEqual(self.reader.get(b'\x90N'), [b'\xaa'])
+    
+    def test_get_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        self.assertEqual(self.reader.get(b'\xe4\xbd\xa0\xe5\xa5\xbd\xef\xbc\x8c\xe4\xb8\x96\xe7\x95\x8c'), [b'hello world'])
+        self.assertEqual(self.reader.get(b'a'), [b'a'])
+        self.assertEqual(self.reader.get(b'\x61'), [b'a'])   
+        self.assertEqual(self.reader.get(b'\x90N'), [b'\xaa'])
+    
+    def test_get_keyerror_returns_none(self):
+        self.assertEqual(self.reader.get('nope'), None)
+
+    def test_get_default(self):
+        expected = 'foobar'
+        self.assertEqual(self.reader.get('nope', expected), expected)
+
     def test_get_range(self):
-        reader = mtbl.reader(self.filepath, verify_checksums=True)
-        result = list(reader.get_range(b'key19', b'key23'))
+        result = list(self.reader.get_range('key19', 'key23'))
+        self.assertEqual([('key2', 'val2'), ('key23', 'val23')], result)
+    
+    def test_get_range_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.get_range('key19', 'key23'))
         self.assertEqual([(b'key2', b'val2'), (b'key23', b'val23')], result)
 
     def test_get_prefix(self):
-        reader = mtbl.reader(self.filepath, verify_checksums=True)
-        result = list(reader.get_prefix(b'key2'))
-        self.assertEqual([(b'key2', b'val2'), (b'key23', b'val23')], result)
-
-    def test_iteritems(self):
-        reader = mtbl.reader(self.filepath, verify_checksums=True)
-        result = list(reader.iteritems())
+        result = list(self.reader.get_prefix(b'key2'))
+        self.assertEqual([('key2', 'val2'), ('key23', 'val23')], result)
+    
+    def test_get_prefix_string(self):
+        result = list(self.reader.get_prefix('key'))
         self.assertEqual(
             [
+                ('key0', b'\xff'),
+                ('key1', 'val1'),
+                ('key17', 'val17'),                
+                ('key2', 'val2'),
+                ('key23', 'val23'),
+                ('key3', 'val3'),
+            ], result)
+    
+    def test_get_prefix_string_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.get_prefix('key'))
+        self.assertEqual(
+            [
+                (b'key0', b'\xff'),
+                (b'key1', b'val1'),
+                (b'key17', b'val17'),                
+                (b'key2', b'val2'),
+                (b'key23', b'val23'),
+                (b'key3', b'val3'),
+            ], result)
+    
+    def test_iterkeys(self):
+        result = list(self.reader.iterkeys())
+        self.assertEqual(
+            [
+                '\x00',                
+                'a',
+                'key0',
+                'key1',
+                'key17',
+                'key2',
+                'key23',
+                'key3',
+                b'\x90N',
+                '你好，世界',
+            ],
+            result,
+        )
+    
+    def test_iterkeys_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.iterkeys())
+        self.assertEqual(
+            [
+                b'\x00',                
+                b'a',
+                b'key0',
+                b'key1',
+                b'key17',
+                b'key2',
+                b'key23',
+                b'key3',
+                b'\x90N',
+                b'\xe4\xbd\xa0\xe5\xa5\xbd\xef\xbc\x8c\xe4\xb8\x96\xe7\x95\x8c',
+            ],
+            result,
+        )
+    
+    def test_itervalues(self):
+        result = list(self.reader.itervalues())
+        self.assertEqual(
+            [
+                '\x01',                
+                'a',
+                b'\xff',
+                'val1',
+                'val17',
+                'val2',
+                'val23',
+                'val3',
+                b'\xaa',
+                'hello world',
+            ],
+            result,
+        )
+    
+    def test_itervalues_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.itervalues())
+        self.assertEqual(
+            [
+                b'\x01',                
+                b'a',
+                b'\xff',
+                b'val1',
+                b'val17',
+                b'val2',
+                b'val23',
+                b'val3',
+                b'\xaa',
+                b'hello world',
+            ],
+            result,
+        )
+
+    def test_iteritems(self):
+        result = list(self.reader.iteritems())
+        self.assertEqual(
+            [
+                ('\x00', '\x01'),                
+                ('a', 'a'),
+                ('key0', b'\xff'),
+                ('key1', 'val1'),
+                ('key17', 'val17'),
+                ('key2', 'val2'),
+                ('key23', 'val23'),
+                ('key3', 'val3'),
+                (b'\x90N', b'\xaa'),
+                ('你好，世界', 'hello world'),
+            ],
+            result,
+        )
+    
+    def test_iteritems_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.iteritems())
+        self.assertEqual(
+            [
+                (b'\x00', b'\x01'),                
+                (b'a', b'a'),
+                (b'key0', b'\xff'),
                 (b'key1', b'val1'),
                 (b'key17', b'val17'),
                 (b'key2', b'val2'),
                 (b'key23', b'val23'),
                 (b'key3', b'val3'),
-                (b'key4', b'val4'),
+                (b'\x90N', b'\xaa'),
+                (b'\xe4\xbd\xa0\xe5\xa5\xbd\xef\xbc\x8c\xe4\xb8\x96\xe7\x95\x8c', b'hello world'),
             ],
             result,
         )

--- a/tests/test_reader_writer.py
+++ b/tests/test_reader_writer.py
@@ -1,0 +1,65 @@
+
+import os
+import unittest
+
+import mtbl
+
+
+class WriterTestCase(unittest.TestCase):
+
+    def test_misordered_write_raises_keyordererror(self):
+        filepath = os.path.join(
+            os.path.dirname(__file__), 'example.mtbl')
+        writer = mtbl.writer(filepath, compression=mtbl.COMPRESSION_NONE)
+        self.addCleanup(os.remove, filepath)
+        writer['key1'] = 'val1'
+        writer['key17'] = 'val17'
+        writer['key2'] = 'val2'
+        writer['key23'] = 'val23'
+        writer['key3'] = 'val3'
+        writer['key4'] = 'val4'
+        with self.assertRaises(mtbl.KeyOrderError):
+            writer['key05'] = 'val05'
+
+
+class ReaderTestCase(unittest.TestCase):
+
+    def setUp(self):
+        super(ReaderTestCase, self).setUp()
+        # write our test mtbl
+        self.filepath = os.path.join(
+            os.path.dirname(__file__), 'example.mtbl')
+        writer = mtbl.writer(self.filepath, compression=mtbl.COMPRESSION_NONE)
+        self.addCleanup(os.remove, self.filepath)
+        writer['key1'] = 'val1'
+        writer['key17'] = 'val17'
+        writer['key2'] = 'val2'
+        writer['key23'] = 'val23'
+        writer['key3'] = 'val3'
+        writer['key4'] = 'val4'
+        writer.close()
+
+    def test_get_range(self):
+        reader = mtbl.reader(self.filepath, verify_checksums=True)
+        result = list(reader.get_range('key19', 'key23'))
+        self.assertEqual([('key2', 'val2'), ('key23', 'val23')], result)
+
+    def test_get_prefix(self):
+        reader = mtbl.reader(self.filepath, verify_checksums=True)
+        result = list(reader.get_prefix('key2'))
+        self.assertEqual([('key2', 'val2'), ('key23', 'val23')], result)
+
+    def test_iteritems(self):
+        reader = mtbl.reader(self.filepath, verify_checksums=True)
+        result = list(reader.iteritems())
+        self.assertEqual(
+            [
+                ('key1', 'val1'),
+                ('key17', 'val17'),
+                ('key2', 'val2'),
+                ('key23', 'val23'),
+                ('key3', 'val3'),
+                ('key4', 'val4'),
+            ],
+            result,
+        )

--- a/tests/test_reader_writer.py
+++ b/tests/test_reader_writer.py
@@ -1,4 +1,16 @@
-
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import unittest
 
@@ -12,14 +24,14 @@ class WriterTestCase(unittest.TestCase):
             os.path.dirname(__file__), 'example.mtbl')
         writer = mtbl.writer(filepath, compression=mtbl.COMPRESSION_NONE)
         self.addCleanup(os.remove, filepath)
-        writer['key1'] = 'val1'
-        writer['key17'] = 'val17'
-        writer['key2'] = 'val2'
-        writer['key23'] = 'val23'
-        writer['key3'] = 'val3'
-        writer['key4'] = 'val4'
+        writer[b'key1'] = b'val1'
+        writer[b'key17'] = b'val17'
+        writer[b'key2'] = b'val2'
+        writer[b'key23'] = b'val23'
+        writer[b'key3'] = b'val3'
+        writer[b'key4'] = b'val4'
         with self.assertRaises(mtbl.KeyOrderError):
-            writer['key05'] = 'val05'
+            writer[b'key05'] = b'val05'
 
 
 class ReaderTestCase(unittest.TestCase):
@@ -31,35 +43,35 @@ class ReaderTestCase(unittest.TestCase):
             os.path.dirname(__file__), 'example.mtbl')
         writer = mtbl.writer(self.filepath, compression=mtbl.COMPRESSION_NONE)
         self.addCleanup(os.remove, self.filepath)
-        writer['key1'] = 'val1'
-        writer['key17'] = 'val17'
-        writer['key2'] = 'val2'
-        writer['key23'] = 'val23'
-        writer['key3'] = 'val3'
-        writer['key4'] = 'val4'
+        writer[b'key1'] = b'val1'
+        writer[b'key17'] = b'val17'
+        writer[b'key2'] = b'val2'
+        writer[b'key23'] = b'val23'
+        writer[b'key3'] = b'val3'
+        writer[b'key4'] = b'val4'
         writer.close()
 
     def test_get_range(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
-        result = list(reader.get_range('key19', 'key23'))
-        self.assertEqual([('key2', 'val2'), ('key23', 'val23')], result)
+        result = list(reader.get_range(b'key19', b'key23'))
+        self.assertEqual([(b'key2', b'val2'), (b'key23', b'val23')], result)
 
     def test_get_prefix(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
-        result = list(reader.get_prefix('key2'))
-        self.assertEqual([('key2', 'val2'), ('key23', 'val23')], result)
+        result = list(reader.get_prefix(b'key2'))
+        self.assertEqual([(b'key2', b'val2'), (b'key23', b'val23')], result)
 
     def test_iteritems(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
         result = list(reader.iteritems())
         self.assertEqual(
             [
-                ('key1', 'val1'),
-                ('key17', 'val17'),
-                ('key2', 'val2'),
-                ('key23', 'val23'),
-                ('key3', 'val3'),
-                ('key4', 'val4'),
+                (b'key1', b'val1'),
+                (b'key17', b'val17'),
+                (b'key2', b'val2'),
+                (b'key23', b'val23'),
+                (b'key3', b'val3'),
+                (b'key4', b'val4'),
             ],
             result,
         )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -27,25 +27,28 @@ class SearchTestCase(MtblTestCase):
         self.write_mtbl(
             self.filepath,
             [
-                (b'key1', b'val1'),
-                (b'key17', b'val17'),
-                (b'key2', b'val2'),
-                (b'key23', b'val23'),
-                (b'key3', b'val3'),
-                (b'key4', b'val4'),
+                ('key1', 'val1'),
+                ('key17', 'val17'),
+                ('key2', 'val2'),
+                ('key23', 'val23'),
+                ('key3', 'val3'),
+                ('key4', 'val4'),
             ],
         )
 
     def test_in(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
         self.assertTrue(b'key23' in reader)
-        self.assertEqual([b'val23'], reader[b'key23'])
+        self.assertEqual(['val23'], reader['key23'])
 
     def test_not_in(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
         self.assertTrue(b'keyfoo' not in reader)
+        self.assertTrue('keyfoo' not in reader)
 
     def test_not_in_raises_keyerror(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
         with self.assertRaises(KeyError):
             reader[b'keyfoo']
+        with self.assertRaises(KeyError):
+            reader['keyfoo']

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,16 @@
-
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 
 import mtbl
@@ -15,25 +27,25 @@ class SearchTestCase(MtblTestCase):
         self.write_mtbl(
             self.filepath,
             [
-                ('key1', 'val1'),
-                ('key17', 'val17'),
-                ('key2', 'val2'),
-                ('key23', 'val23'),
-                ('key3', 'val3'),
-                ('key4', 'val4'),
+                (b'key1', b'val1'),
+                (b'key17', b'val17'),
+                (b'key2', b'val2'),
+                (b'key23', b'val23'),
+                (b'key3', b'val3'),
+                (b'key4', b'val4'),
             ],
         )
 
     def test_in(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
-        self.assertTrue('key23' in reader)
-        self.assertEqual(['val23'], reader['key23'])
+        self.assertTrue(b'key23' in reader)
+        self.assertEqual([b'val23'], reader[b'key23'])
 
     def test_not_in(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
-        self.assertTrue('keyfoo' not in reader)
+        self.assertTrue(b'keyfoo' not in reader)
 
     def test_not_in_raises_keyerror(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
         with self.assertRaises(KeyError):
-            reader['keyfoo']
+            reader[b'keyfoo']

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,39 @@
+
+import os
+
+import mtbl
+from . import MtblTestCase
+
+
+class SearchTestCase(MtblTestCase):
+
+    def setUp(self):
+        super(SearchTestCase, self).setUp()
+        # write our test mtbl
+        self.filepath = os.path.join(
+            os.path.dirname(__file__), 'example.mtbl')
+        self.write_mtbl(
+            self.filepath,
+            [
+                ('key1', 'val1'),
+                ('key17', 'val17'),
+                ('key2', 'val2'),
+                ('key23', 'val23'),
+                ('key3', 'val3'),
+                ('key4', 'val4'),
+            ],
+        )
+
+    def test_in(self):
+        reader = mtbl.reader(self.filepath, verify_checksums=True)
+        self.assertTrue('key23' in reader)
+        self.assertEqual(['val23'], reader['key23'])
+
+    def test_not_in(self):
+        reader = mtbl.reader(self.filepath, verify_checksums=True)
+        self.assertTrue('keyfoo' not in reader)
+
+    def test_not_in_raises_keyerror(self):
+        reader = mtbl.reader(self.filepath, verify_checksums=True)
+        with self.assertRaises(KeyError):
+            reader['keyfoo']

--- a/tests/test_sorter.py
+++ b/tests/test_sorter.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2015-2021 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import unittest
+
+import mtbl
+
+def merge_func(key, val0, val1):
+    return val0 + b' sorted ' + val1
+
+def make_sort(return_bytes=False):
+    # create the sorted mtbl
+    sorter = mtbl.sorter(merge_func, return_bytes=return_bytes)
+    test_data = [
+        ('key0', 'val0'),
+        ('key0', 'val01'),
+        ('key1', 'val1'),
+        ('key2', 'val2'),
+        ('key3', 'val3'),
+        ('key3', 'val31')
+    ]
+    
+    for d in test_data:
+        sorter[d[0]] = d[1]
+    return sorter
+
+class SorterTestCase(unittest.TestCase):
+    
+    def test_sort_with_merging(self):
+        sorter =  make_sort()
+
+        # check our results
+        result = list(sorter.iteritems())
+        self.assertEqual(
+            [
+                ('key0', 'val0 sorted val01'),
+                ('key1', 'val1'),
+                ('key2', 'val2'),
+                ('key3', 'val3 sorted val31')
+            ],
+            result,
+        )
+    
+    def test_sort_iteritems_as_bytes(self):
+        # create the sorted mtbl but this time read as bytes
+        sorter =  make_sort(True)
+        
+        result = list(sorter.iteritems())
+
+        self.assertEqual(
+            [
+                (b'key0', b'val0 sorted val01'),
+                (b'key1', b'val1'),
+                (b'key2', b'val2'),
+                (b'key3', b'val3 sorted val31')
+            ],
+            result,
+        )
+    
+    def test_sort_iterreturn_bytes(self):
+        # create the sorted mtbl but this time read as bytes
+        sorter =  make_sort(True)
+        
+        result = list(sorter.iterkeys())
+
+        self.assertEqual(
+            [
+                (b'key0'),
+                (b'key1'),
+                (b'key2'),
+                (b'key3')
+            ],
+            result,
+        )
+    
+    def test_sort_itervalues_as_bytes(self):
+        # create the sorted mtbl but this time read as bytes
+        sorter =  make_sort(True)
+        
+        result = list(sorter.itervalues())
+
+        self.assertEqual(
+            [
+                (b'val0 sorted val01'),
+                (b'val1'),
+                (b'val2'),
+                (b'val3 sorted val31')
+            ],
+            result,
+        )

--- a/tests/test_to_bytes.py
+++ b/tests/test_to_bytes.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2015-2021 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import unittest
+
+import mtbl
+
+class ToBytesTestCase(unittest.TestCase):
+
+    def test_string_to_bytes(self):
+        expected = b'foobar'
+        actual = mtbl.to_bytes('foobar')
+        self.assertEqual(actual, expected)
+    
+    def test_byte_string_to_bytes(self):
+        expected = b'foobar'
+        actual = mtbl.to_bytes(expected)
+        self.assertEqual(actual, expected)
+
+    def test_bytes_varint_to_bytes(self):
+        expected = b'\xc4\xb8\xd30\x00\x00\x00'
+        actual = mtbl.to_bytes(b'\xc4\xb8\xd30\x00\x00\x00')
+        self.assertEqual(actual, expected)
+
+    def test_bytearray_to_bytes(self):
+        expected = b'\xde\xad\xbe\xef'
+        actual = mtbl.to_bytes(bytearray(b'\xde\xad\xbe\xef'))
+        self.assertEqual(actual, expected)
+    
+    def test_to_bytes_raises_valueerror_with_list(self):
+        self.assertRaises(ValueError, mtbl.to_bytes, ['a', 'b', 'c', 'd'])
+    
+    def test_to_bytes_raises_valueerror_with_int(self):
+        self.assertRaises(ValueError, mtbl.to_bytes, 42)
+    

--- a/tests/test_varint.py
+++ b/tests/test_varint.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2015-2019 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from mtbl import *
+
+
+class TestVarint(unittest.TestCase):
+    def test_0_ret_type(self):
+        assert type(varint_encode(100)) == bytes
+
+    def test_0_arg_type(self):
+        x = varint_decode(b'\xc4\xb8\xd30\x00\x00\x00')
+        x = varint_decode(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))
+
+        # py2 will accept the following, but py3 will not
+        # bc in py2 type 'bytes' is a synonym for type 'str'
+        # note that you cant reliably use .encode() since these are
+        # byte buffers and not guaranteed to be some sort of encoded string
+        # so the following should be avoided in client scripts or you
+        # risk portability
+        # x = varint_decode('\xc4\xb8\xd30\x00\x00\x00')
+
+    def test_inverse(self):
+        assert 123 == varint_decode(varint_encode(123))
+
+    def test_length(self):
+        assert 1 == varint_length(1)
+        assert 2 == varint_length(1000)
+        assert 2 == varint_length_packed(varint_encode(1000))
+        assert 4 == varint_length_packed(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))
+        assert 4 == varint_length_packed(b'\xc4\xb8\xd30\x00\x00\x00')
+
+    def test_insitu_decode(self):
+        assert 102030404 == varint_decode(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_varint.py
+++ b/tests/test_varint.py
@@ -23,14 +23,8 @@ class TestVarint(unittest.TestCase):
     def test_0_arg_type(self):
         x = varint_decode(b'\xc4\xb8\xd30\x00\x00\x00')
         x = varint_decode(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))
-
-        # py2 will accept the following, but py3 will not
-        # bc in py2 type 'bytes' is a synonym for type 'str'
-        # note that you cant reliably use .encode() since these are
-        # byte buffers and not guaranteed to be some sort of encoded string
-        # so the following should be avoided in client scripts or you
-        # risk portability
-        # x = varint_decode('\xc4\xb8\xd30\x00\x00\x00')
+        x = varint_decode('\xc4\xb8\xd30\x00\x00\x00')
+        
 
     def test_inverse(self):
         assert 123 == varint_decode(varint_encode(123))
@@ -41,6 +35,7 @@ class TestVarint(unittest.TestCase):
         assert 2 == varint_length_packed(varint_encode(1000))
         assert 4 == varint_length_packed(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))
         assert 4 == varint_length_packed(b'\xc4\xb8\xd30\x00\x00\x00')
+        assert 1 == varint_length_packed('foo')
 
     def test_insitu_decode(self):
         assert 102030404 == varint_decode(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))


### PR DESCRIPTION
This is a major version bump. The use of 'bytes' introduces a breaking change where client scripts will need to be updated when they are migrated to Python 3. See the README for details. 

This commit includes various type adjustments (const, bytes)
to support Python 3. Unit tests have been updated to validate
functionality. Example scripts have also been updated. Everything
is tested against Python 2.7 and 3.5 on Debian 8/9.

Other misc changes include doc and setup improvements as well
as copyright boilerplate adjustments.

This also includes the changes in the PR for the minimal-tests branch.