### PR TITLE
Allow strings py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+venv*

--- a/README.md
+++ b/README.md
@@ -72,19 +72,25 @@ If you want to disable this behavior and read the contents of the mtbl as bytes 
 r = mtbl.reader('example.mtbl', verify_checksums=True, return_bytes=True)
 ```
 
+If you want to store integers in your mtbl use varint_encode() and varint_decode() or [struct.pack](https://docs.python.org/3.9/library/struct.html#struct.pack) and [struct.unpack](https://docs.python.org/3.9/library/struct.html#struct.pack) to do so:
+
 ```
 import mtbl
+import struct
+
 w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
 w['key0'] = mtbl.varint_encode(2)
 w['key1'] = mtbl.varint_encode(128)
 w['key2'] = mtbl.varint_encode(98765432100)
+w['key3'] = struct.pack('I', 123)
 w.close()
 
-r = mtbl.reader('example.mtbl', verify_checksums=True)
+r = mtbl.reader('example.mtbl', verify_checksums=True, return_bytes=True)
 
 assert mtbl.varint_decode(r.get('key0')[0]) == 2
 assert mtbl.varint_decode(r.get('key1')[0]) == 128
 assert mtbl.varint_decode(r.get('key2')[0]) == 98765432100
+assert struct.unpack('I', r.get('key3')[0])[0] == 123
 ```
 
 
@@ -102,8 +108,8 @@ Now you would write:
 
 ```
 x = mtbl.varint_encode(1234)
-if type(x) == str:  # py2
+if type(x) == str: # py2
     first_byte = ord(x[0])
-else:                        # py3
+else: # py3
     first_byte = x[0]
 ```

--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ import mtbl
 w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
 w['key0'] = mtbl.varint_encode(2)
 w['key1'] = mtbl.varint_encode(128)
+w['key2'] = mtbl.varint_encode(98765432100)
 w.close()
 
 r = mtbl.reader('example.mtbl', verify_checksums=True)
 
 assert mtbl.varint_decode(r.get('key0')[0]) == 2
 assert mtbl.varint_decode(r.get('key1')[0]) == 128
+assert mtbl.varint_decode(r.get('key2')[0]) == 98765432100
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ assert r.get('key2') == ['~']
 assert r.get('key3') == [b'\x80\x01'] # not a printable string so the value read back is bytes
 ```
 
-If you want to store integers in your mtbl use varint_encode() and varint_decode() to do so:
+If you want to disable this behavior and read the contents of the mtbl as bytes then initialize your reader with `return_bytes=True`
+
+```
+r = mtbl.reader('example.mtbl', verify_checksums=True, return_bytes=True)
+```
 
 ```
 import mtbl

--- a/README.md
+++ b/README.md
@@ -9,45 +9,80 @@ writer interfaces (nb. the traceback is expected behavior):
 
     >>> import mtbl
     >>> w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
-    >>> w[b'key1'] = b'val1'
-    >>> w[b'key17'] = b'val17'
-    >>> w[b'key2'] = b'val2'
-    >>> w[b'key23'] = b'val23'
-    >>> w[b'key3'] = b'val3'
-    >>> w[b'key4'] = b'val4'
-    >>> w[b'key05'] = b'val05'
+    >>> w['key1'] = 'val1'
+    >>> w['key17'] = 'val17'
+    >>> w['key2'] = 'val2'
+    >>> w['key23'] = 'val23'
+    >>> w['key3'] = 'val3'
+    >>> w['key4'] = 'val4'
+    >>> w['key05'] = 'val05'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File "mtbl.pyx", line 361, in mtbl.writer.__setitem__ (mtbl.c:4108)
     mtbl.KeyOrderError
     >>> w.close()
     >>> r = mtbl.reader('example.mtbl', verify_checksums=True)
-    >>> for k,v in r.get_range(b'key19', b'key23'): print(k, v)
+    >>> for k,v in r.get_range('key19', 'key23'): print(k, v)
     ... 
-    b'key2' b'val2'
-    b'key23' b'val23'
-    >>> for k,v in r.get_prefix(b'key2'): print(k, v)
+    'key2' 'val2'
+    'key23' 'val23'
+    >>> for k,v in r.get_prefix('key2'): print(k, v)
     ... 
-    b'key2' b'val2'
-    b'key23' b'val23'
+    'key2' 'val2'
+    'key23' 'val23'
     >>> for k,v in r.iteritems(): print(k, v)
     ... 
-    b'key1' b'val1'
-    b'key17' b'val17'
-    b'key2' b'val2'
-    b'key23' b'val23'
-    b'key3' b'val3'
-    b'key4' b'val4'
+    'key1' 'val1'
+    'key17' 'val17'
+    'key2' 'val2'
+    'key23' 'val23'
+    'key3' 'val3'
+    'key4' 'val4'
     >>>
 
 
 In Python 3.x bytes() is a distinct type, whereas in Python 2.6 and 2.7 
-it is simply an alias for str(). We now take bytes as function parameters
-instead of strings. This is done because, in Python 3, not all byte strings
-can be encoded as printable strings and so accepting a str as a parameter was
-not practical since mtbl is used, frequently, to store arbitrary byte data.
+it is simply an alias for str(). We now take strings and bytes as function parameters. Note that if you pass in a byte 
+string that can be UTF-8 decoded it will be read back from the mtbl as a str.
 
-Scripts that used ord() to determine the value of a byte in a buffer returned
+For example:
+
+```
+import mtbl
+w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
+w[b'key0'] = b'val0'
+w[b'key1'] = b'\x01'
+w[b'key2'] = b'\x7e'
+w[b'key3'] = b'\x80\x01'
+w.close()
+
+r = mtbl.reader('example.mtbl', verify_checksums=True)
+
+assert r.get(b'key0') == ['val0']
+# all the keys in this mtbl are strings because they can all be UTF-8 decoded
+assert [type(k) for k in list(r.iterkeys())] == [str, str, str, str]
+assert r.get('key1') == ['\x01']
+assert r.get('key2') == ['~']
+assert r.get('key3') == [b'\x80\x01'] # not a printable string so the value read back is bytes
+```
+
+If you want to store integers in your mtbl use varint_encode() and varint_decode() to do so:
+
+```
+import mtbl
+w = mtbl.writer('example.mtbl', compression=mtbl.COMPRESSION_SNAPPY)
+w['key0'] = mtbl.varint_encode(2)
+w['key1'] = mtbl.varint_encode(128)
+w.close()
+
+r = mtbl.reader('example.mtbl', verify_checksums=True)
+
+assert mtbl.varint_decode(r.get('key0')[0]) == 2
+assert mtbl.varint_decode(r.get('key1')[0]) == 128
+```
+
+
+Finally, scripts that used ord() to determine the value of a byte in a buffer returned
 by this module under Python 2 will now need to test the data type. 
 
 For example, in pymtbl<=0.4.0 you might have written:
@@ -61,31 +96,8 @@ Now you would write:
 
 ```
 x = mtbl.varint_encode(1234)
-if type(first_type) == str:  # py2
+if type(x) == str:  # py2
     first_byte = ord(x[0])
 else:                        # py3
     first_byte = x[0]
 ```
-
-Additionally, you must now pass in bytes to functions like
-varint_encode and writer. Previously, you were able to write either
-`w['key1'] = 'val1'` or `w[b'key1'] = b'val1'` because of Python 2's 
-definition of bytes == str. Now you must write either
-
- `w[b'key1'] = b'val1'` 
- 
- `w['key1'.encode()] = 'val1'.encode()`
-
-While `w['key1'] = 'val1'` will continue to work when using Python 2, it will
-*not* work when using Python 3 and so to maximize portability of your scripts, you 
-should avoid that form.
-
-If you intend to store strings, you should call encode() to ensure they
-are stored with an encoding that you define.
-
-References
-----------
-
-https://candide-guevara.github.io/article/python/2018/02/28/cython-memory-mgt.html
-https://github.com/cython/cython/blob/master/tests/run/bytearray_coercion.pyx
-

--- a/examples/pymtbl_make_random_table.py
+++ b/examples/pymtbl_make_random_table.py
@@ -45,19 +45,19 @@ def main(fname, num_keys):
             last_secs = b - last
             last = b
             sys.stderr.write('wrote %s entries (%s MB) in %s seconds, %s entries/second\n' % (
-                locale.format('%d', total, grouping=True),
-                locale.format('%d', total_bytes / megabyte, grouping=True),
-                locale.format('%f', last_secs, grouping=True),
-                locale.format('%d', report_interval / last_secs, grouping=True)
+                locale.format_string('%d', total, grouping=True),
+                locale.format_string('%d', total_bytes / megabyte, grouping=True),
+                locale.format_string('%f', last_secs, grouping=True),
+                locale.format_string('%d', report_interval / last_secs, grouping=True)
                 )
             )
     b = time.time()
     total_secs = b - a
     sys.stderr.write('wrote %s total entries (%s MB) in %s seconds, %s entries/second\n' % (
-        locale.format('%d', total, grouping=True),
-        locale.format('%d', total_bytes / megabyte, grouping=True),
-        locale.format('%f', total_secs, grouping=True),
-        locale.format('%d', total / total_secs, grouping=True)
+        locale.format_string('%d', total, grouping=True),
+        locale.format_string('%d', total_bytes / megabyte, grouping=True),
+        locale.format_string('%f', total_secs, grouping=True),
+        locale.format_string('%d', total / total_secs, grouping=True)
         )
     )
 

--- a/examples/pymtbl_make_random_table_2.py
+++ b/examples/pymtbl_make_random_table_2.py
@@ -50,10 +50,10 @@ def main(fname, num_keys):
             last_secs = b - last
             last = b
             sys.stderr.write('generated %s entries (%s MB) in %s seconds, %s entries/second\n' % (
-                locale.format('%d', count, grouping=True),
-                locale.format('%d', total_bytes / megabyte, grouping=True),
-                locale.format('%f', last_secs, grouping=True),
-                locale.format('%d', report_interval / last_secs, grouping=True)
+                locale.format_string('%d', count, grouping=True),
+                locale.format_string('%d', total_bytes / megabyte, grouping=True),
+                locale.format_string('%f', last_secs, grouping=True),
+                locale.format_string('%d', report_interval / last_secs, grouping=True)
                 )
             )
     sys.stderr.write('writing to output file %s\n' % fname)
@@ -61,10 +61,10 @@ def main(fname, num_keys):
     b = time.time()
     total_secs = b - a
     sys.stderr.write('wrote %s total entries (%s MB) in %s seconds, %s entries/second\n' % (
-        locale.format('%d', count, grouping=True),
-        locale.format('%d', total_bytes / megabyte, grouping=True),
-        locale.format('%f', total_secs, grouping=True),
-        locale.format('%d', count / total_secs, grouping=True)
+        locale.format_string('%d', count, grouping=True),
+        locale.format_string('%d', total_bytes / megabyte, grouping=True),
+        locale.format_string('%f', total_secs, grouping=True),
+        locale.format_string('%d', count / total_secs, grouping=True)
         )
     )
 

--- a/examples/pymtbl_search_random_table.py
+++ b/examples/pymtbl_search_random_table.py
@@ -40,19 +40,19 @@ def main(fname, num_keys, num_iters):
             last_secs = b - last
             last = b
             sys.stderr.write('%s lookups, %s keys found in %s seconds, %s lookups/second\n' % (
-                locale.format('%d', count, grouping=True),
-                locale.format('%d', num_found, grouping=True),
-                locale.format('%f', last_secs, grouping=True),
-                locale.format('%d', report_interval / last_secs, grouping=True)
+                locale.format_string('%d', count, grouping=True),
+                locale.format_string('%d', num_found, grouping=True),
+                locale.format_string('%f', last_secs, grouping=True),
+                locale.format_string('%d', report_interval / last_secs, grouping=True)
                 )
             )
     b = time.time()
     total_secs = b - a
     sys.stderr.write('%s total lookups, %s keys found in %s seconds, %s lookups/second\n' % (
-        locale.format('%d', count, grouping=True),
-        locale.format('%d', num_found, grouping=True),
-        locale.format('%f', total_secs, grouping=True),
-        locale.format('%d', count / total_secs, grouping=True)
+        locale.format_string('%d', count, grouping=True),
+        locale.format_string('%d', num_found, grouping=True),
+        locale.format_string('%f', total_secs, grouping=True),
+        locale.format_string('%d', count / total_secs, grouping=True)
         )
     )
 

--- a/mtbl.pyx
+++ b/mtbl.pyx
@@ -324,7 +324,7 @@ cdef class reader(DictMixin):
         self.check_initialized()
         return get_iteritems(self, mtbl_source_iter(mtbl_reader_source(self._instance)))
 
-    def __contains__(self, bytes py_key):
+    def __contains__(self, py_key):
         """R.__contains__(k) -> True if R has a key k, else False"""
         try:
             self.__getitem__(py_key)
@@ -333,11 +333,11 @@ cdef class reader(DictMixin):
             pass
         return False
 
-    def has_key(self, bytes py_key):
+    def has_key(self, py_key):
         """R.has_key(k) -> True if R has a key k, else False."""
         return self.__contains__(py_key)
 
-    def get(self, bytes py_key, default=None):
+    def get(self, py_key, default=None):
         """R.get(k[,d]) -> R[k] if k in R, else d.  d defaults to None."""
         try:
             return self.__getitem__(py_key)
@@ -345,7 +345,7 @@ cdef class reader(DictMixin):
             pass
         return default
 
-    def get_range(self, bytes py_key0, bytes py_key1):
+    def get_range(self, py_key0, py_key1):
         """
         R.get_range(key0, key1) -> an iterator over all (key, value) items in R where key is
         between key0 and key1 inclusive.
@@ -358,17 +358,17 @@ cdef class reader(DictMixin):
 
         self.check_initialized()
 
-        t = py_key0
+        t = to_bytes(py_key0)
         key0 = <uint8_t *> t
-        t = py_key1
-        key1 = <uint8_t *> t
-        len_key0 = len(py_key0)
-        len_key1 = len(py_key1)
+        len_key0 = len(t)
+        t = to_bytes(py_key1)
+        key1 = <uint8_t *> t        
+        len_key1 = len(t)
 
         return get_iteritems(self, mtbl_source_get_range(
             mtbl_reader_source(self._instance), key0, len_key0, key1, len_key1))
 
-    def get_prefix(self, bytes py_key):
+    def get_prefix(self, py_key):
         """
         R.get_prefix(key_prefix) -> an iterator over all (key, value) items in R where key
         begins with key_prefix.
@@ -379,14 +379,14 @@ cdef class reader(DictMixin):
 
         self.check_initialized()
 
-        t = py_key
+        t = to_bytes(py_key)
         key = <uint8_t *> t
-        len_key = len(py_key)
+        len_key = len(t)
 
         return get_iteritems(self, mtbl_source_get_prefix(
             mtbl_reader_source(self._instance), key, len_key))
 
-    def __getitem__(self, bytes py_key):
+    def __getitem__(self, py_key):
         cdef mtbl_iter *it
         cdef mtbl_res res
         cdef const uint8_t *key
@@ -396,9 +396,9 @@ cdef class reader(DictMixin):
 
         self.check_initialized()
 
-        t = py_key
+        t = to_bytes(py_key)        
         key = <uint8_t *> t
-        len_key = len(py_key)
+        len_key = len(t)
 
         items = []
         with nogil:

--- a/mtbl.pyx
+++ b/mtbl.pyx
@@ -105,8 +105,8 @@ def varint_decode(py_buf):
     cdef Py_ssize_t len_buf
     cdef size_t bytes_read
 
-    if type(py_buf) == bytearray or type(py_buf) == str:
-        py_buf = bytes(py_buf)
+    # This allows the function to accept strings like '\x01' in py3
+    py_buf = to_bytes(py_buf)
 
     buf = <uint8_t *> py_buf
     len_buf = len(py_buf)

--- a/mtbl.pyx
+++ b/mtbl.pyx
@@ -105,7 +105,7 @@ def varint_decode(py_buf):
     cdef Py_ssize_t len_buf
     cdef size_t bytes_read
 
-    # This allows the function to accept strings like '\x01' in py3
+    # This allows the function to accept strings like '\x01' to '\x7f' in py3
     py_buf = to_bytes(py_buf)
 
     buf = <uint8_t *> py_buf

--- a/tests/test_from_bytes.py
+++ b/tests/test_from_bytes.py
@@ -57,3 +57,12 @@ class StrFromBytesTestCase(unittest.TestCase):
         actual = mtbl.from_bytes(expected)
         self.assertEqual(actual, expected)
     
+    def test_from_bytes_with_byte_string_as_bytes(self):
+        expected = b'foobar'
+        actual = mtbl.from_bytes(expected, True)
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_byte_string_as_bytes2(self):
+        expected = b'\x01'
+        actual = mtbl.from_bytes(expected, True)
+        self.assertEqual(actual, expected)

--- a/tests/test_from_bytes.py
+++ b/tests/test_from_bytes.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015-2021 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import unittest
+import sys
+
+import mtbl
+
+class StrFromBytesTestCase(unittest.TestCase):
+
+    def test_from_bytes_with_byte_string(self):
+        expected = 'foobar'
+        actual = mtbl.from_bytes(expected.encode('utf-8'))
+        self.assertEqual(actual, expected)
+    
+    @unittest.skipIf(sys.version_info[0] >= 3, 'py3 can handle unicode')
+    def test_from_bytes_with_nonascii_byte_string(self):
+        expected = '\xe4\xbd\xa0\xe5\xa5\xbd'
+        actual = mtbl.from_bytes(u'你好'.encode('utf-8'))
+        self.assertEqual(actual, expected)
+    
+    @unittest.skipIf(sys.version_info[0] == 2, 'py2 can\'t handle unicode')
+    def test_from_bytes_with_nonascii_byte_string(self):
+        expected = '你好'
+        actual = mtbl.from_bytes(expected.encode('utf-8'))
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_non_string(self):
+        expected = b'\x90N'
+        actual = mtbl.from_bytes(expected)
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_non_string2(self):
+        expected = b'\xc4\xb8\xd30\x00\x00\x00'
+        actual = mtbl.from_bytes(expected)
+        self.assertEqual(actual, expected)
+    
+    def test_from_bytes_with_deadbeef(self):
+        expected = b'\xde\xad\xbe\xef'
+        actual = mtbl.from_bytes(expected)
+        self.assertEqual(actual, expected)
+
+    def test_from_bytes_with_128(self):
+        expected = b'\x80\x01' # b'\x80\x01' == mtbl.varint_encode(128)
+        actual = mtbl.from_bytes(expected)
+        self.assertEqual(actual, expected)
+    

--- a/tests/test_reader_writer.py
+++ b/tests/test_reader_writer.py
@@ -24,14 +24,18 @@ class WriterTestCase(unittest.TestCase):
             os.path.dirname(__file__), 'example.mtbl')
         writer = mtbl.writer(filepath, compression=mtbl.COMPRESSION_NONE)
         self.addCleanup(os.remove, filepath)
-        writer[b'key1'] = b'val1'
-        writer[b'key17'] = b'val17'
-        writer[b'key2'] = b'val2'
-        writer[b'key23'] = b'val23'
+        writer[b'key1'] = 'val1'
+        writer['key17'] = b'val17'
+        writer['key2'] = 'val2'
+        writer['key23'] = 'val23'
         writer[b'key3'] = b'val3'
         writer[b'key4'] = b'val4'
         with self.assertRaises(mtbl.KeyOrderError):
+            writer['key05'] = 'val05'
+        with self.assertRaises(mtbl.KeyOrderError):
             writer[b'key05'] = b'val05'
+        # this one should not raise mtbl.KeyOrderError
+        writer['key5'] = 'key5'
 
 
 class ReaderTestCase(unittest.TestCase):

--- a/tests/test_reader_writer.py
+++ b/tests/test_reader_writer.py
@@ -79,6 +79,13 @@ class ReaderTestCase(unittest.TestCase):
         self.assertEqual(self.reader.get(b'\x61'), ['a'])   
         self.assertEqual(self.reader.get(b'\x90N'), [b'\xaa'])
     
+    def test_get_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        self.assertEqual(self.reader.get(b'\xe4\xbd\xa0\xe5\xa5\xbd\xef\xbc\x8c\xe4\xb8\x96\xe7\x95\x8c'), [b'hello world'])
+        self.assertEqual(self.reader.get(b'a'), [b'a'])
+        self.assertEqual(self.reader.get(b'\x61'), [b'a'])   
+        self.assertEqual(self.reader.get(b'\x90N'), [b'\xaa'])
+    
     def test_get_keyerror_returns_none(self):
         self.assertEqual(self.reader.get('nope'), None)
 
@@ -89,6 +96,11 @@ class ReaderTestCase(unittest.TestCase):
     def test_get_range(self):
         result = list(self.reader.get_range('key19', 'key23'))
         self.assertEqual([('key2', 'val2'), ('key23', 'val23')], result)
+    
+    def test_get_range_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.get_range('key19', 'key23'))
+        self.assertEqual([(b'key2', b'val2'), (b'key23', b'val23')], result)
 
     def test_get_prefix(self):
         result = list(self.reader.get_prefix(b'key2'))
@@ -106,6 +118,19 @@ class ReaderTestCase(unittest.TestCase):
                 ('key3', 'val3'),
             ], result)
     
+    def test_get_prefix_string_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.get_prefix('key'))
+        self.assertEqual(
+            [
+                (b'key0', b'\xff'),
+                (b'key1', b'val1'),
+                (b'key17', b'val17'),                
+                (b'key2', b'val2'),
+                (b'key23', b'val23'),
+                (b'key3', b'val3'),
+            ], result)
+    
     def test_iterkeys(self):
         result = list(self.reader.iterkeys())
         self.assertEqual(
@@ -120,6 +145,25 @@ class ReaderTestCase(unittest.TestCase):
                 'key3',
                 b'\x90N',
                 '你好，世界',
+            ],
+            result,
+        )
+    
+    def test_iterkeys_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.iterkeys())
+        self.assertEqual(
+            [
+                b'\x00',                
+                b'a',
+                b'key0',
+                b'key1',
+                b'key17',
+                b'key2',
+                b'key23',
+                b'key3',
+                b'\x90N',
+                b'\xe4\xbd\xa0\xe5\xa5\xbd\xef\xbc\x8c\xe4\xb8\x96\xe7\x95\x8c',
             ],
             result,
         )
@@ -141,6 +185,25 @@ class ReaderTestCase(unittest.TestCase):
             ],
             result,
         )
+    
+    def test_itervalues_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.itervalues())
+        self.assertEqual(
+            [
+                b'\x01',                
+                b'a',
+                b'\xff',
+                b'val1',
+                b'val17',
+                b'val2',
+                b'val23',
+                b'val3',
+                b'\xaa',
+                b'hello world',
+            ],
+            result,
+        )
 
     def test_iteritems(self):
         result = list(self.reader.iteritems())
@@ -156,6 +219,25 @@ class ReaderTestCase(unittest.TestCase):
                 ('key3', 'val3'),
                 (b'\x90N', b'\xaa'),
                 ('你好，世界', 'hello world'),
+            ],
+            result,
+        )
+    
+    def test_iteritems_as_bytes(self):
+        self.reader = mtbl.reader(self.filepath, verify_checksums=True, return_bytes=True)
+        result = list(self.reader.iteritems())
+        self.assertEqual(
+            [
+                (b'\x00', b'\x01'),                
+                (b'a', b'a'),
+                (b'key0', b'\xff'),
+                (b'key1', b'val1'),
+                (b'key17', b'val17'),
+                (b'key2', b'val2'),
+                (b'key23', b'val23'),
+                (b'key3', b'val3'),
+                (b'\x90N', b'\xaa'),
+                (b'\xe4\xbd\xa0\xe5\xa5\xbd\xef\xbc\x8c\xe4\xb8\x96\xe7\x95\x8c', b'hello world'),
             ],
             result,
         )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -27,25 +27,28 @@ class SearchTestCase(MtblTestCase):
         self.write_mtbl(
             self.filepath,
             [
-                (b'key1', b'val1'),
-                (b'key17', b'val17'),
-                (b'key2', b'val2'),
-                (b'key23', b'val23'),
-                (b'key3', b'val3'),
-                (b'key4', b'val4'),
+                ('key1', 'val1'),
+                ('key17', 'val17'),
+                ('key2', 'val2'),
+                ('key23', 'val23'),
+                ('key3', 'val3'),
+                ('key4', 'val4'),
             ],
         )
 
     def test_in(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
         self.assertTrue(b'key23' in reader)
-        self.assertEqual([b'val23'], reader[b'key23'])
+        self.assertEqual(['val23'], reader['key23'])
 
     def test_not_in(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
         self.assertTrue(b'keyfoo' not in reader)
+        self.assertTrue('keyfoo' not in reader)
 
     def test_not_in_raises_keyerror(self):
         reader = mtbl.reader(self.filepath, verify_checksums=True)
         with self.assertRaises(KeyError):
             reader[b'keyfoo']
+        with self.assertRaises(KeyError):
+            reader['keyfoo']

--- a/tests/test_sorter.py
+++ b/tests/test_sorter.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2015-2021 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import mtbl
+from . import MtblTestCase
+
+def merge_func(key, val0, val1):
+    return val0 + ' sorted ' + val1
+
+class SorterTestCase(MtblTestCase):
+    def setUp(self):
+        super(SorterTestCase, self).setUp()
+    
+    def test_sort_with_merging(self):
+        # create the sorted mtbl
+        sorter = mtbl.sorter(merge_func)
+        sorted_filename = os.path.join(os.path.dirname(__file__), 'sorted.mtbl')
+        writer = mtbl.writer(
+            sorted_filename, compression=mtbl.COMPRESSION_NONE)
+        self.addCleanup(os.remove, sorted_filename)
+
+        test_data = [
+            ('key0', 'val0'),
+            ('key0', 'val01'),
+            ('key1', 'val1'),
+            ('key2', 'val2'),
+            ('key3', 'val3'),
+            ('key3', 'val31')
+        ]
+        for d in test_data:
+            sorter[d[0]] = d[1]
+
+        # write the mtbl
+        sorter.write(writer)
+        writer.close()
+
+        # check our results
+        reader = mtbl.reader(sorted_filename, verify_checksums=True)
+        result = list(reader.iteritems())
+        self.assertEqual(
+            [
+                ('key0', 'val0 sorted val01'),
+                ('key1', 'val1'),
+                ('key2', 'val2'),
+                ('key3', 'val3 sorted val31')
+            ],
+            result,
+        )

--- a/tests/test_to_bytes.py
+++ b/tests/test_to_bytes.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2015-2021 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import unittest
+
+import mtbl
+
+class ToBytesTestCase(unittest.TestCase):
+
+    def test_string_to_bytes(self):
+        expected = b'foobar'
+        actual = mtbl.to_bytes('foobar')
+        self.assertEqual(actual, expected)
+    
+    def test_byte_string_to_bytes(self):
+        expected = b'foobar'
+        actual = mtbl.to_bytes(expected)
+        self.assertEqual(actual, expected)
+
+    def test_bytes_varint_to_bytes(self):
+        expected = b'\xc4\xb8\xd30\x00\x00\x00'
+        actual = mtbl.to_bytes(b'\xc4\xb8\xd30\x00\x00\x00')
+        self.assertEqual(actual, expected)
+
+    def test_bytearray_to_bytes(self):
+        expected = b'\xde\xad\xbe\xef'
+        actual = mtbl.to_bytes(bytearray(b'\xde\xad\xbe\xef'))
+        self.assertEqual(actual, expected)
+    
+    def test_to_bytes_raises_valueerror_with_list(self):
+        self.assertRaises(ValueError, mtbl.to_bytes, ['a', 'b', 'c', 'd'])
+    
+    def test_to_bytes_raises_valueerror_with_int(self):
+        self.assertRaises(ValueError, mtbl.to_bytes, 42)
+    

--- a/tests/test_varint.py
+++ b/tests/test_varint.py
@@ -41,6 +41,7 @@ class TestVarint(unittest.TestCase):
         assert 2 == varint_length_packed(varint_encode(1000))
         assert 4 == varint_length_packed(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))
         assert 4 == varint_length_packed(b'\xc4\xb8\xd30\x00\x00\x00')
+        assert 1 == varint_length_packed('foo')
 
     def test_insitu_decode(self):
         assert 102030404 == varint_decode(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))

--- a/tests/test_varint.py
+++ b/tests/test_varint.py
@@ -23,14 +23,8 @@ class TestVarint(unittest.TestCase):
     def test_0_arg_type(self):
         x = varint_decode(b'\xc4\xb8\xd30\x00\x00\x00')
         x = varint_decode(bytearray(b'\xc4\xb8\xd30\x00\x00\x00'))
-
-        # py2 will accept the following, but py3 will not
-        # bc in py2 type 'bytes' is a synonym for type 'str'
-        # note that you cant reliably use .encode() since these are
-        # byte buffers and not guaranteed to be some sort of encoded string
-        # so the following should be avoided in client scripts or you
-        # risk portability
-        # x = varint_decode('\xc4\xb8\xd30\x00\x00\x00')
+        x = varint_decode('\xc4\xb8\xd30\x00\x00\x00')
+        
 
     def test_inverse(self):
         assert 123 == varint_decode(varint_encode(123))


### PR DESCRIPTION
This allows users to pass in strings for keys and values in python3 which makes the interface similar to how it was in python2. I also added a bunch more unittests.