### PR TITLE
Fix build with cython 3.X

### DIFF
--- a/mtbl.pxi
+++ b/mtbl.pxi
@@ -14,7 +14,6 @@
 # limitations under the License.
 cimport cython
 from cpython cimport bool
-from cpython.string cimport *
 from libc.stddef cimport *
 from libc.stdint cimport *
 from libc.stdlib cimport *


### PR DESCRIPTION
Allow building with cython 3.X, while mantaining compatibility with cython 0.3.